### PR TITLE
Interface with MathProgBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 Compat
+MathProgBase

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -51,6 +51,7 @@ end
 
 include("core_interface.jl")
 include("julia_interface.jl")
+include("MathProgBase_interface.jl")
 
 # Decode problem and build shared library.
 function sifdecoder(name :: ASCIIString)

--- a/src/MathProgBase_interface.jl
+++ b/src/MathProgBase_interface.jl
@@ -1,0 +1,67 @@
+module MathProgBaseInterface
+
+using CUTEst
+import MathProgBase
+import MathProgBase.SolverInterface
+
+type CUTEstNLPEvaluator <: SolverInterface.AbstractNLPEvaluator
+  nlp::CUTEstModel
+end
+
+# What is this?
+MathProgBase.initialize(::CUTEstNLPEvaluator, request_features) = nothing
+MathProgBase.features_available(::CUTEstNLPEvaluator) = [:Grad, :Jac, :HessVec,
+    :Hess]
+
+MathProgBase.eval_f(d::CUTEstNLPEvaluator, x) = obj(d.nlp, x)
+
+MathProgBase.eval_g(d::CUTEstNLPEvaluator, g, x) = copy!(g, cons(d.nlp, x))
+
+function MathProgBase.eval_grad_f(d::CUTEstNLPEvaluator, g, x)
+  f, gx = objgrad(d.nlp, x, true)
+  copy!(g, gx)
+end
+
+function MathProgBase.jac_structure(d::CUTEstNLPEvaluator)
+  c, rows, cols, vals = cons_coord(d.nlp, d.nlp.meta.x0, true)
+  return rows, cols
+end
+
+function MathProgBase.hesslag_structure(d::CUTEstNLPEvaluator)
+  rows, cols, vals = hess_coord(d.nlp, d.nlp.meta.x0, ones(d.nlp.meta.ncon))
+  return rows, cols
+end
+
+function MathProgBase.eval_jac_g(d::CUTEstNLPEvaluator, J, x)
+  c, rows, cols, vals = cons_coord(d.nlp, x, true)
+  copy!(J, vals)
+end
+
+function MathProgBase.eval_hesslag_prod(d::CUTEstNLPEvaluator, h, x, v, σ, μ)
+  if abs(σ) < 1e-12
+    error("CUTEst.jl does not handle zero scalar weight")
+  end
+  y = μ/σ
+  result = σ*hprod(d.nlp, x, y, v)
+  copy!(h, result)
+end
+
+function MathProgBase.eval_hesslag(d::CUTEstNLPEvaluator, H, x, σ, μ)
+  if abs(σ) < 1e-12
+    error("CUTEst.jl does not handle zero scalar weight")
+  end
+  y = μ/σ
+  (hrow, hcol, hval) = hess_coord(d.nlp, x, y)
+  return hval*σ
+end
+
+MathProgBase.isconstrlinear(d::CUTEstNLPEvaluator, i::Int) = (i in d.nlp.meta.lin)
+
+function load_cutest_problem!(m::MathProgBase.AbstractMathProgModel,
+    nlp::CUTEstModel)
+  MathProgBase.loadnonlinearproblem!(m, nlp.meta.nvar, nlp.meta.ncon,
+      nlp.meta.lvar, nlp.meta.uvar, nlp.meta.lcon, nlp.meta.ucon, :Min,
+      CUTEstNLPEvaluator(nlp))
+end
+
+end # module


### PR DESCRIPTION
Implements #22.

This doesn't have a travis test yet.
I [tested](https://gist.github.com/abelsiqueira/d0a8fa2507b271a77be5) with `Ipopt.jl` in v0.4.

This has room to improvement, especially with the inplace function calls, but I'd rather wait for the intermediate interface, since it will be much cleaner then.