### PR TITLE
Fix issue4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ install:
 
 script:
   - julia --check-bounds=yes -E 'Pkg.test("CUTEst"; coverage=true)'
-  - julia --check-bounds=yes -E 'cd(Pkg.dir("CUTEst")); include("test/runtests_unc.jl")'
 
 after_success:
   - julia -e 'cd(Pkg.dir("CUTEst")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ os:
   - linux
   - osx
 
+matrix:
+  allow_failures:
+    - os: osx
+
 julia:
   - release
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ os:
   - linux
   - osx
 
-matrix:
-  allow_failures:
-    - os: osx
-
 julia:
   - release
   - nightly
@@ -16,7 +12,7 @@ sudo: required
 
 before_install:
   # Install Linuxbrew.
-  - if [ `uname` == "Linux" ]; then unset DYLD_LIBRARY_PATH; bash travisCI/setup_travis_linux.sh; export PATH="$HOME/.linuxbrew/bin:$PATH"; export LD_LIBRARY_PATH="$HOME/.linuxbrew/lib:$LD_LIBRARY_PATH"; fi
+  - if [ `uname` == "Linux" ]; then unset DYLD_LIBRARY_PATH; bash travisCI/setup_travis_linux.sh; export PATH="$HOME/.linuxbrew/bin:$PATH"; export LD_LIBRARY_PATH="$HOME/.linuxbrew/lib:$LD_LIBRARY_PATH"; export HOMEBREW_BUILD_FROM_SOURCE=1; fi
   - brew --config
   - brew doctor || true
   - brew update
@@ -25,9 +21,9 @@ before_install:
 
 install:
   # Install CUTEst.
-  - brew tap dpo/cutest
-  - brew install cutest --HEAD
-  - brew install mastsif --HEAD
+  - brew tap optimizers/cutest
+  - brew install cutest
+  - brew install mastsif
   - for f in archdefs mastsif cutest sifdecode; do . $(brew --prefix $f)/$f.bashrc; done
   - if [ `uname` == "Linux" ]; then rm ~/julia/lib/julia/libgfortran.so.3; fi
   - julia -e 'versioninfo()'

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -5,15 +5,15 @@ module CUTEst
 push!(LOAD_PATH, Pkg.dir("MathProgBase","src","NLP"))
 using NLP  # Defines NLPModelMeta.
 using Compat
+import Base.Libdl.dlsym
+
+# Only one problem can be interfaced at any given time.
+global cutest_instances = 0
 
 export CUTEstModel, sifdecoder, cutest_finalize
 
-# Only one problem can be interfaced at any given time.
-cutest_instances = 0;
-
 type CUTEstModel
   meta    :: NLPModelMeta;
-  cutest_lib :: Ptr{Void}
 end
 
 const cutest_arch  = get(ENV, "MYARCH", "");
@@ -49,29 +49,12 @@ macro cutest_error()  # Handle nonzero exit codes.
   :(io_err[1] > 0 && throw(CUTEstException(io_err[1])))
 end
 
-# Taken from
-# http://docs.julialang.org/en/release-0.4/manual/calling-c-and-fortran-code/#indirect-calls
-macro dlsym(func, lib)
-  z, zlocal = gensym(string(func)), gensym()
-  eval(current_module(), :(global $z = C_NULL))
-  z = esc(z)
-  quote
-    let $zlocal::Ptr{Void} = $z::Ptr{Void}
-      if $zlocal == C_NULL
-        $zlocal = Libdl.dlsym($(esc(lib))::Ptr{Void}, $(esc(func)))
-        global $z = $zlocal
-      end
-      $zlocal
-    end
-  end
-end
-
 include("core_interface.jl")
 include("specialized_interface.jl")
 include("julia_interface.jl")
 include("documentation.jl")
 
-# Decode problem and build shared library.
+  # Decode problem and build shared library.
 function sifdecoder(name :: ASCIIString)
   # TODO: Accept options to pass to sifdecoder.
   pname, sif = splitext(name);
@@ -80,26 +63,27 @@ function sifdecoder(name :: ASCIIString)
   run(`gfortran -c -fPIC ELFUN.f EXTER.f GROUP.f RANGE.f`);
   run(`$linker $sh_flags -o $libname.$soname ELFUN.o EXTER.o GROUP.o RANGE.o -L$cutest_dir/objects/$cutest_arch/double -lcutest_double`);
   run(`rm ELFUN.f EXTER.f GROUP.f RANGE.f ELFUN.o EXTER.o GROUP.o RANGE.o`);
-  push!(Libdl.DL_LOAD_PATH,".")
-  cutest_lib = Libdl.dlopen(libname)
-  return cutest_lib
+  push!(Libdl.DL_LOAD_PATH, ".")
+  global cutest_lib = Libdl.dlopen(libname,
+      Libdl.RTLD_NOW | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL)
 end
 
 # Initialize problem.
 function CUTEstModel(name :: ASCIIString; decode :: Bool=true)
   global cutest_instances
   cutest_instances > 0 && error("CUTEst: call cutest_finalize on current model first")
+  global cutest_lib
   if !decode
-    (isfile(outsdif) & isfile(automat)) || error("CUTEst: no decoded problem found")
+    (isfile(outsdif) && isfile(automat)) || error("CUTEst: no decoded problem found")
     libname = "lib$name"
     isfile("$libname.$soname") || error("CUTEst: lib not found; decode problem first")
-    cutest_lib = Libdl.dlopen(libname)
+    cutest_lib = Libdl.dlopen(libname,
+        Libdl.RTLD_NOW | Libdl.RTLD_DEEPBIND | Libdl.RTLD_GLOBAL)
   else
-    cutest_lib = sifdecoder(name)
+    sifdecoder(name)
   end
   io_err = Cint[0];
-
-  ccall(@dlsym(:fortran_open_, cutest_lib), Void,
+  ccall(dlsym(cutest_lib, :fortran_open_), Void,
       (Ptr{Int32}, Ptr{UInt8}, Ptr{Int32}), &funit, outsdif, io_err);
   @cutest_error
 
@@ -107,7 +91,7 @@ function CUTEstModel(name :: ASCIIString; decode :: Bool=true)
   nvar = Cint[0];
   ncon = Cint[0];
 
-  cdimen(io_err, [funit], nvar, ncon, cutest_lib)
+  cdimen(io_err, [funit], nvar, ncon)
   @cutest_error
   nvar = nvar[1];
   ncon = ncon[1];
@@ -123,10 +107,10 @@ function CUTEstModel(name :: ASCIIString; decode :: Bool=true)
 
   if ncon > 0
     # Equality constraints first, linear constraints first, nonlinear variables first.
-    csetup(io_err, [funit], Cint[5], Cint[6], [nvar], [ncon], x, bl, bu, v, cl, cu,
-      equatn, linear, Cint[1], Cint[1], Cint[1], cutest_lib)
+    csetup(io_err, [funit], Cint[0], Cint[6], [nvar], [ncon], x, bl, bu, v, cl, cu,
+      equatn, linear, Cint[1], Cint[1], Cint[1])
   else
-    usetup(io_err, [funit], Cint[5], Cint[6], [nvar], x, bl, bu, cutest_lib)
+    usetup(io_err, [funit], Cint[0], Cint[6], [nvar], x, bl, bu)
   end
   @cutest_error
 
@@ -139,18 +123,18 @@ function CUTEstModel(name :: ASCIIString; decode :: Bool=true)
   nnzj = Cint[0];
 
   if ncon > 0
-    cdimsh(io_err, nnzh, cutest_lib)
-    cdimsj(io_err, nnzj, cutest_lib)
+    cdimsh(io_err, nnzh)
+    cdimsj(io_err, nnzj)
     nnzj[1] -= nvar;  # nnzj also counts the nonzeros in the objective gradient.
   else
-    udimsh(io_err, nnzh, cutest_lib)
+    udimsh(io_err, nnzh)
   end
   @cutest_error
 
   nnzh = nnzh[1];
   nnzj = nnzj[1];
 
-  ccall(@dlsym(:fortran_close_, cutest_lib), Void,
+  ccall(dlsym(cutest_lib, :fortran_close_), Void,
       (Ptr{Int32}, Ptr{Int32}), &funit, io_err);
   @cutest_error
 
@@ -161,9 +145,8 @@ function CUTEstModel(name :: ASCIIString; decode :: Bool=true)
                       nlin=nlin, nnln=nnln,
                       name=splitext(name)[1]);
 
-  nlp = CUTEstModel(meta, cutest_lib);
+  nlp = CUTEstModel(meta)
 
-  finalizer(nlp, cutest_finalize);
   cutest_instances += 1;
   return nlp
 end
@@ -172,14 +155,17 @@ end
 function cutest_finalize(nlp :: CUTEstModel)
   global cutest_instances
   cutest_instances == 0 && return;
+  global cutest_lib
   io_err = Cint[0];
   if nlp.meta.ncon > 0
-    cterminate(io_err, nlp.cutest_lib)
+    cterminate(io_err)
   else
-    uterminate(io_err, nlp.cutest_lib)
+    uterminate(io_err)
   end
   @cutest_error
+  Libdl.dlclose(cutest_lib)
   cutest_instances -= 1;
+  cutest_lib = C_NULL
   return;
 end
 

--- a/src/core_interface.jl
+++ b/src/core_interface.jl
@@ -8,18 +8,8 @@ export usetup, csetup, udimen, udimsh, udimse, uvartype, unames,
 
 function usetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
     io_buffer::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_usetup_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, input, out, io_buffer, n, x, x_l, x_u)
-end
-
-function usetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
-    io_buffer::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_usetup_", cutest_lib), Void,
+    x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1})
+  ccall(dlsym(cutest_lib, "cutest_usetup_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
     Ptr{Cdouble}, Ptr{Cdouble}),
     io_err, input, out, io_buffer, n, x, x_l, x_u)
@@ -30,10 +20,8 @@ function csetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 
     x::Array{Cdouble, 1}, x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1},
     y::Array{Cdouble, 1}, c_l::Array{Cdouble, 1}, c_u::Array{Cdouble, 1},
     equatn::Array{Cint, 1}, linear::Array{Cint, 1}, e_order::Array{Cint,
-    1}, l_order::Array{Cint, 1}, v_order::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_csetup_", cutest_lib), Void,
+    1}, l_order::Array{Cint, 1}, v_order::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_csetup_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
     Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
@@ -41,161 +29,67 @@ function csetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 
     linear, e_order, l_order, v_order)
 end
 
-function csetup(io_err::Array{Cint, 1}, input::Array{Cint, 1}, out::Array{Cint, 1},
-    io_buffer::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, x_l::Array{Cdouble, 1}, x_u::Array{Cdouble, 1},
-    y::Array{Cdouble, 1}, c_l::Array{Cdouble, 1}, c_u::Array{Cdouble, 1},
-    equatn::Array{Cint, 1}, linear::Array{Cint, 1}, e_order::Array{Cint,
-    1}, l_order::Array{Cint, 1}, v_order::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_csetup_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn,
-    linear, e_order, l_order, v_order)
-end
-
-function udimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_udimen_", cutest_lib), Void,
+function udimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_udimen_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, input, n)
 end
 
-function udimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_udimen_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, input, n)
-end
-
-function udimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_udimsh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}),
-    io_err, nnzh)
-end
-
-function udimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_udimsh_", cutest_lib), Void,
+function udimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_udimsh_"), Void,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzh)
 end
 
 function udimse(io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
-    he_row_ne::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_udimse_", cutest_lib), Void,
+    he_row_ne::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_udimse_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, ne, he_val_ne, he_row_ne)
 end
 
-function udimse(io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
-    he_row_ne::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_udimse_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, ne, he_val_ne, he_row_ne)
-end
-
-function uvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_uvartype_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x_type)
-end
-
-function uvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_uvartype_", cutest_lib), Void,
+function uvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_uvartype_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, x_type)
 end
 
 function unames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, pname::Array{Cchar, 1},
-    vname::Array{Cchar, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_unames_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}, Ptr{Cchar}),
-    io_err, n, pname, vname)
-end
-
-function unames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, pname::Array{Cchar, 1},
-    vname::Array{Cchar, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_unames_", cutest_lib), Void,
+    vname::Array{Cchar, 1})
+  ccall(dlsym(cutest_lib, "cutest_unames_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}, Ptr{Cchar}),
     io_err, n, pname, vname)
 end
 
 function ureport(io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
-    1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ureport_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, calls, time)
-end
-
-function ureport(io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
-    1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ureport_", cutest_lib), Void,
+    1})
+  ccall(dlsym(cutest_lib, "cutest_ureport_"), Void,
     (Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
     io_err, calls, time)
 end
 
 function cdimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1},
-    m::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cdimen_", cutest_lib), Void,
+    m::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cdimen_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, input, n, m)
 end
 
-function cdimen(io_err::Array{Cint, 1}, input::Array{Cint, 1}, n::Array{Cint, 1},
-    m::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cdimen_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, input, n, m)
-end
-
-function cdimsj(io_err::Array{Cint, 1}, nnzj::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cdimsj_", cutest_lib), Void,
+function cdimsj(io_err::Array{Cint, 1}, nnzj::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cdimsj_"), Void,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzj)
 end
 
-function cdimsj(io_err::Array{Cint, 1}, nnzj::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cdimsj_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}),
-    io_err, nnzj)
-end
-
-function cdimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cdimsh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}),
-    io_err, nnzh)
-end
-
-function cdimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cdimsh_", cutest_lib), Void,
+function cdimsh(io_err::Array{Cint, 1}, nnzh::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cdimsh_"), Void,
     (Ptr{Cint}, Ptr{Cint}),
     io_err, nnzh)
 end
 
 function cdimse(io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
-    he_row_ne::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cdimse_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, ne, he_val_ne, he_row_ne)
-end
-
-function cdimse(io_err::Array{Cint, 1}, ne::Array{Cint, 1}, he_val_ne::Array{Cint, 1},
-    he_row_ne::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cdimse_", cutest_lib), Void,
+    he_row_ne::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cdimse_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, ne, he_val_ne, he_row_ne)
 end
@@ -203,175 +97,75 @@ end
 function cstats(io_err::Array{Cint, 1}, nonlinear_variables_objective::Array{Cint, 1},
     nonlinear_variables_constraints::Array{Cint, 1},
     equality_constraints::Array{Cint, 1}, linear_constraints::Array{Cint,
-    1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cstats_", cutest_lib), Void,
+    1})
+  ccall(dlsym(cutest_lib, "cutest_cstats_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, nonlinear_variables_objective,
     nonlinear_variables_constraints, equality_constraints,
     linear_constraints)
 end
 
-function cstats(io_err::Array{Cint, 1}, nonlinear_variables_objective::Array{Cint, 1},
-    nonlinear_variables_constraints::Array{Cint, 1},
-    equality_constraints::Array{Cint, 1}, linear_constraints::Array{Cint,
-    1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cstats_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, nonlinear_variables_objective,
-    nonlinear_variables_constraints, equality_constraints,
-    linear_constraints)
-end
-
-function cvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cvartype_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x_type)
-end
-
-function cvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cvartype_", cutest_lib), Void,
+function cvartype(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x_type::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cvartype_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, x_type)
 end
 
 function cnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    pname::Array{Cchar, 1}, vname::Array{Cchar, 1}, cname::Array{Cchar,
-    1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cnames_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}, Ptr{Cchar}, Ptr{Cchar}),
-    io_err, n, m, pname, vname, cname)
-end
-
-function cnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    pname::Array{Cchar, 1}, vname::Array{Cchar, 1}, cname::Array{Cchar,
-    1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cnames_", cutest_lib), Void,
+    pname::Array{Cchar, 1}, vname::Array{Cchar, 1}, cname::Array{Cchar, 1})
+  ccall(dlsym(cutest_lib, "cutest_cnames_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}, Ptr{Cchar}, Ptr{Cchar}),
     io_err, n, m, pname, vname, cname)
 end
 
 function creport(io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
-    1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_creport_", cutest_lib), Void,
+    1})
+  ccall(dlsym(cutest_lib, "cutest_creport_"), Void,
     (Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
     io_err, calls, time)
 end
 
-function creport(io_err::Array{Cint, 1}, calls::Array{Cdouble, 1}, time::Array{Cdouble,
-    1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_creport_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, calls, time)
-end
-
-function connames(io_err::Array{Cint, 1}, m::Array{Cint, 1}, cname::Array{Cchar, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_connames_", cutest_lib), Void,
+function connames(io_err::Array{Cint, 1}, m::Array{Cint, 1}, cname::Array{Cchar, 1})
+  ccall(dlsym(cutest_lib, "cutest_connames_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
     io_err, m, cname)
 end
 
-function connames(io_err::Array{Cint, 1}, m::Array{Cint, 1}, cname::Array{Cchar, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_connames_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
-    io_err, m, cname)
-end
-
-function pname(io_err::Array{Cint, 1}, input::Array{Cint, 1}, pname::Array{Cchar, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_pname_", cutest_lib), Void,
+function pname(io_err::Array{Cint, 1}, input::Array{Cint, 1}, pname::Array{Cchar, 1})
+  ccall(dlsym(cutest_lib, "cutest_pname_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
     io_err, input, pname)
 end
 
-function pname(io_err::Array{Cint, 1}, input::Array{Cint, 1}, pname::Array{Cchar, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_pname_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
-    io_err, input, pname)
-end
-
-function probname(io_err::Array{Cint, 1}, pname::Array{Cchar, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_probname_", cutest_lib), Void,
+function probname(io_err::Array{Cint, 1}, pname::Array{Cchar, 1})
+  ccall(dlsym(cutest_lib, "cutest_probname_"), Void,
     (Ptr{Cint}, Ptr{Cchar}),
     io_err, pname)
 end
 
-function probname(io_err::Array{Cint, 1}, pname::Array{Cchar, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_probname_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cchar}),
-    io_err, pname)
-end
-
-function varnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, vname::Array{Cchar, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_varnames_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
-    io_err, n, vname)
-end
-
-function varnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, vname::Array{Cchar, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_varnames_", cutest_lib), Void,
+function varnames(io_err::Array{Cint, 1}, n::Array{Cint, 1}, vname::Array{Cchar, 1})
+  ccall(dlsym(cutest_lib, "cutest_varnames_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cchar}),
     io_err, n, vname)
 end
 
 function ufn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ufn_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, n, x, f)
-end
-
-function ufn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ufn_", cutest_lib), Void,
+    f::Array{Cdouble, 1})
+  ccall(dlsym(cutest_lib, "cutest_ufn_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
     io_err, n, x, f)
 end
 
 function ugr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ugr_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, n, x, g)
-end
-
-function ugr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ugr_", cutest_lib), Void,
+    g::Array{Cdouble, 1})
+  ccall(dlsym(cutest_lib, "cutest_ugr_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}),
     io_err, n, x, g)
 end
 
 function uofg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_uofg_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}),
-    io_err, n, x, f, g, grad)
-end
-
-function uofg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_uofg_", cutest_lib), Void,
+    f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_uofg_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}),
     io_err, n, x, f, g, grad)
@@ -379,54 +173,24 @@ end
 
 function ubandh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     semibandwidth::Array{Cint, 1}, h_band::Array{Cdouble, 2},
-    lbandh::Array{Cint, 1}, max_semibandwidth::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ubandh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
-end
-
-function ubandh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    semibandwidth::Array{Cint, 1}, h_band::Array{Cdouble, 2},
-    lbandh::Array{Cint, 1}, max_semibandwidth::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ubandh_", cutest_lib), Void,
+    lbandh::Array{Cint, 1}, max_semibandwidth::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_ubandh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cint}),
     io_err, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
 end
 
 function udh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    lh1::Array{Cint, 1}, h::Array{Cdouble, 2}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_udh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, x, lh1, h)
-end
-
-function udh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    lh1::Array{Cint, 1}, h::Array{Cdouble, 2}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_udh_", cutest_lib), Void,
+    lh1::Array{Cint, 1}, h::Array{Cdouble, 2})
+  ccall(dlsym(cutest_lib, "cutest_udh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}),
     io_err, n, x, lh1, h)
 end
 
 function ush(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     nnzh::Array{Cint, 1}, lh::Array{Cint, 1}, h_val::Array{Cdouble, 1},
-    h_row::Array{Cint, 1}, h_col::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ush_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x, nnzh, lh, h_val, h_row, h_col)
-end
-
-function ush(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    nnzh::Array{Cint, 1}, lh::Array{Cint, 1}, h_val::Array{Cdouble, 1},
-    h_row::Array{Cint, 1}, h_col::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ush_", cutest_lib), Void,
+    h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_ush_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
     Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, x, nnzh, lh, h_val, h_row, h_col)
@@ -436,23 +200,8 @@ function ueh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     ne::Array{Cint, 1}, lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint,
     1}, he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
     he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
-    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ueh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, x, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
-    lhe_val, he_val, byrows)
-end
-
-function ueh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    ne::Array{Cint, 1}, lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint,
-    1}, he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
-    he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
-    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ueh_", cutest_lib), Void,
+    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_ueh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
     io_err, n, x, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
@@ -460,19 +209,8 @@ function ueh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
 end
 
 function ugrdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ugrdh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
-    Ptr{Cdouble}),
-    io_err, n, x, g, lh1, h)
-end
-
-function ugrdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ugrdh_", cutest_lib), Void,
+    g::Array{Cdouble, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2})
+  ccall(dlsym(cutest_lib, "cutest_ugrdh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
     Ptr{Cdouble}),
     io_err, n, x, g, lh1, h)
@@ -480,20 +218,8 @@ end
 
 function ugrsh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     g::Array{Cdouble, 1}, nnzh::Array{Cint, 1}, lh::Array{Cint, 1},
-    h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
-    1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ugrsh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x, g, nnzh, lh, h_val, h_row, h_col)
-end
-
-function ugrsh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, nnzh::Array{Cint, 1}, lh::Array{Cint, 1},
-    h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
-    1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ugrsh_", cutest_lib), Void,
+    h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_ugrsh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
     Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, x, g, nnzh, lh, h_val, h_row, h_col)
@@ -503,24 +229,8 @@ function ugreh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     g::Array{Cdouble, 1}, ne::Array{Cint, 1}, lhe_ptr::Array{Cint, 1},
     he_row_ptr::Array{Cint, 1}, he_val_ptr::Array{Cint, 1},
     lhe_row::Array{Cint, 1}, he_row::Array{Cint, 1}, lhe_val::Array{Cint,
-    1}, he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ugreh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, x, g, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
-    lhe_val, he_val, byrows)
-end
-
-function ugreh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, ne::Array{Cint, 1}, lhe_ptr::Array{Cint, 1},
-    he_row_ptr::Array{Cint, 1}, he_val_ptr::Array{Cint, 1},
-    lhe_row::Array{Cint, 1}, he_row::Array{Cint, 1}, lhe_val::Array{Cint,
-    1}, he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ugreh_", cutest_lib), Void,
+    1}, he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_ugreh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
     Ptr{Cdouble}, Ptr{Cint}),
@@ -530,56 +240,24 @@ end
 
 function uhprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, goth::Array{Cint, 1},
     x::Array{Cdouble, 1}, vector::Array{Cdouble, 1},
-    result::Array{Cdouble, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_uhprod_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cdouble}),
-    io_err, n, goth, x, vector, result)
-end
-
-function uhprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, goth::Array{Cint, 1},
-    x::Array{Cdouble, 1}, vector::Array{Cdouble, 1},
-    result::Array{Cdouble, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_uhprod_", cutest_lib), Void,
+    result::Array{Cdouble, 1})
+  ccall(dlsym(cutest_lib, "cutest_uhprod_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cdouble}),
     io_err, n, goth, x, vector, result)
 end
 
 function cfn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, f::Array{Cdouble, 1}, c::Array{Cdouble, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cfn_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cdouble}),
-    io_err, n, m, x, f, c)
-end
-
-function cfn(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, f::Array{Cdouble, 1}, c::Array{Cdouble, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cfn_", cutest_lib), Void,
+    x::Array{Cdouble, 1}, f::Array{Cdouble, 1}, c::Array{Cdouble, 1})
+  ccall(dlsym(cutest_lib, "cutest_cfn_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cdouble}),
     io_err, n, m, x, f, c)
 end
 
 function cofg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cofg_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}),
-    io_err, n, x, f, g, grad)
-end
-
-function cofg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cofg_", cutest_lib), Void,
+    f::Array{Cdouble, 1}, g::Array{Cdouble, 1}, grad::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cofg_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}),
     io_err, n, x, f, g, grad)
@@ -587,20 +265,8 @@ end
 
 function cofsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     f::Array{Cdouble, 1}, nnzg::Array{Cint, 1}, lg::Array{Cint, 1},
-    g_val::Array{Cdouble, 1}, g_var::Array{Cint, 1}, grad::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cofsg_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x, f, nnzg, lg, g_val, g_var, grad)
-end
-
-function cofsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    f::Array{Cdouble, 1}, nnzg::Array{Cint, 1}, lg::Array{Cint, 1},
-    g_val::Array{Cdouble, 1}, g_var::Array{Cint, 1}, grad::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cofsg_", cutest_lib), Void,
+    g_val::Array{Cdouble, 1}, g_var::Array{Cint, 1}, grad::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cofsg_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint},
     Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, x, f, nnzg, lg, g_val, g_var, grad)
@@ -609,19 +275,8 @@ end
 function ccfg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, c::Array{Cdouble, 1}, jtrans::Array{Cint, 1},
     lcjac1::Array{Cint, 1}, lcjac2::Array{Cint, 1}, cjac::Array{Cdouble,
-    2}, grad::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ccfg_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
-end
-
-function ccfg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, c::Array{Cdouble, 1}, jtrans::Array{Cint, 1},
-    lcjac1::Array{Cint, 1}, lcjac2::Array{Cint, 1}, cjac::Array{Cdouble,
-    2}, grad::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ccfg_", cutest_lib), Void,
+    2}, grad::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_ccfg_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
     io_err, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
@@ -629,18 +284,8 @@ end
 
 function clfg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, f::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, grad::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_clfg_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, x, y, f, g, grad)
-end
-
-function clfg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, f::Array{Cdouble, 1},
-    g::Array{Cdouble, 1}, grad::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_clfg_", cutest_lib), Void,
+    g::Array{Cdouble, 1}, grad::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_clfg_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cint}),
     io_err, n, m, x, y, f, g, grad)
@@ -649,19 +294,8 @@ end
 function cgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
     g::Array{Cdouble, 1}, jtrans::Array{Cint, 1}, lj1::Array{Cint, 1},
-    lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cgr_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
-end
-
-function cgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
-    g::Array{Cdouble, 1}, jtrans::Array{Cint, 1}, lj1::Array{Cint, 1},
-    lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cgr_", cutest_lib), Void,
+    lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2})
+  ccall(dlsym(cutest_lib, "cutest_cgr_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
     io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
@@ -670,19 +304,8 @@ end
 function csgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
     nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
-    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_csgr_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
-end
-
-function csgr(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
-    nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
-    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_csgr_", cutest_lib), Void,
+    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_csgr_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
@@ -691,19 +314,8 @@ end
 function ccfsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, c::Array{Cdouble, 1}, nnzj::Array{Cint, 1},
     lj::Array{Cint, 1}, j_val::Array{Cdouble, 1}, j_var::Array{Cint, 1},
-    j_fun::Array{Cint, 1}, grad::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ccfsg_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
-end
-
-function ccfsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, c::Array{Cdouble, 1}, nnzj::Array{Cint, 1},
-    lj::Array{Cint, 1}, j_val::Array{Cdouble, 1}, j_var::Array{Cint, 1},
-    j_fun::Array{Cint, 1}, grad::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ccfsg_", cutest_lib), Void,
+    j_fun::Array{Cint, 1}, grad::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_ccfsg_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
@@ -711,18 +323,8 @@ end
 
 function ccifg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
     x::Array{Cdouble, 1}, ci::Array{Cdouble, 1}, gci::Array{Cdouble, 1},
-    grad::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ccifg_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, icon, x, ci, gci, grad)
-end
-
-function ccifg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
-    x::Array{Cdouble, 1}, ci::Array{Cdouble, 1}, gci::Array{Cdouble, 1},
-    grad::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ccifg_", cutest_lib), Void,
+    grad::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_ccifg_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cdouble}, Ptr{Cint}),
     io_err, n, icon, x, ci, gci, grad)
@@ -731,19 +333,8 @@ end
 function ccifsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
     x::Array{Cdouble, 1}, ci::Array{Cdouble, 1}, nnzgci::Array{Cint, 1},
     lgci::Array{Cint, 1}, gci_val::Array{Cdouble, 1}, gci_var::Array{Cint,
-    1}, grad::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ccifsg_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
-end
-
-function ccifsg(io_err::Array{Cint, 1}, n::Array{Cint, 1}, icon::Array{Cint, 1},
-    x::Array{Cdouble, 1}, ci::Array{Cdouble, 1}, nnzgci::Array{Cint, 1},
-    lgci::Array{Cint, 1}, gci_val::Array{Cdouble, 1}, gci_var::Array{Cint,
-    1}, grad::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ccifsg_", cutest_lib), Void,
+    1}, grad::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_ccifsg_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
@@ -753,21 +344,8 @@ function cgrdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
     g::Array{Cdouble, 1}, jtrans::Array{Cint, 1}, lj1::Array{Cint, 1},
     lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2}, lh1::Array{Cint, 1},
-    h_val::Array{Cdouble, 2}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cgrdh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
-end
-
-function cgrdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
-    g::Array{Cdouble, 1}, jtrans::Array{Cint, 1}, lj1::Array{Cint, 1},
-    lj2::Array{Cint, 1}, j_val::Array{Cdouble, 2}, lh1::Array{Cint, 1},
-    h_val::Array{Cdouble, 2}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cgrdh_", cutest_lib), Void,
+    h_val::Array{Cdouble, 2})
+  ccall(dlsym(cutest_lib, "cutest_cgrdh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
     Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}),
@@ -776,18 +354,8 @@ end
 
 function cdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, lh1::Array{Cint, 1},
-    h_val::Array{Cdouble, 2}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cdh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, m, x, y, lh1, h_val)
-end
-
-function cdh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, lh1::Array{Cint, 1},
-    h_val::Array{Cdouble, 2}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cdh_", cutest_lib), Void,
+    h_val::Array{Cdouble, 2})
+  ccall(dlsym(cutest_lib, "cutest_cdh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cdouble}),
     io_err, n, m, x, y, lh1, h_val)
@@ -796,19 +364,8 @@ end
 function csh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, nnzh::Array{Cint, 1},
     lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
-    h_col::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_csh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
-end
-
-function csh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, nnzh::Array{Cint, 1},
-    lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
-    h_col::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_csh_", cutest_lib), Void,
+    h_col::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_csh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
@@ -817,19 +374,8 @@ end
 function cshc(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, nnzh::Array{Cint, 1},
     lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
-    h_col::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cshc_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
-end
-
-function cshc(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, nnzh::Array{Cint, 1},
-    lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
-    h_col::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cshc_", cutest_lib), Void,
+    h_col::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cshc_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
@@ -840,25 +386,8 @@ function ceh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint, 1},
     he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
     he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
-    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_ceh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, x, y, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row,
-    he_row, lhe_val, he_val, byrows)
-end
-
-function ceh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, ne::Array{Cint, 1},
-    lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint, 1},
-    he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
-    he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
-    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_ceh_", cutest_lib), Void,
+    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_ceh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
     Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
@@ -867,38 +396,16 @@ function ceh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
 end
 
 function cidh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    iprob::Array{Cint, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cidh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
-    io_err, n, x, iprob, lh1, h)
-end
-
-function cidh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    iprob::Array{Cint, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cidh_", cutest_lib), Void,
+    iprob::Array{Cint, 1}, lh1::Array{Cint, 1}, h::Array{Cdouble, 2})
+  ccall(dlsym(cutest_lib, "cutest_cidh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
     io_err, n, x, iprob, lh1, h)
 end
 
 function cish(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
     iprob::Array{Cint, 1}, nnzh::Array{Cint, 1}, lh::Array{Cint, 1},
-    h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
-    1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cish_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
-end
-
-function cish(io_err::Array{Cint, 1}, n::Array{Cint, 1}, x::Array{Cdouble, 1},
-    iprob::Array{Cint, 1}, nnzh::Array{Cint, 1}, lh::Array{Cint, 1},
-    h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
-    1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cish_", cutest_lib), Void,
+    h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cish_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
     Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
     io_err, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
@@ -909,23 +416,8 @@ function csgrsh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
     j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, nnzh::Array{Cint, 1},
     lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
-    h_col::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_csgrsh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
-    io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, nnzh, lh,
-    h_val, h_row, h_col)
-end
-
-function csgrsh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
-    nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
-    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, nnzh::Array{Cint, 1},
-    lh::Array{Cint, 1}, h_val::Array{Cdouble, 1}, h_row::Array{Cint, 1},
-    h_col::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_csgrsh_", cutest_lib), Void,
+    h_col::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_csgrsh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint}),
@@ -940,29 +432,8 @@ function csgreh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint, 1},
     he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
     he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
-    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_csgreh_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
-    Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, ne,
-    lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val,
-    byrows)
-end
-
-function csgreh(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    x::Array{Cdouble, 1}, y::Array{Cdouble, 1}, grlagf::Array{Cint, 1},
-    nnzj::Array{Cint, 1}, lj::Array{Cint, 1}, j_val::Array{Cdouble, 1},
-    j_var::Array{Cint, 1}, j_fun::Array{Cint, 1}, ne::Array{Cint, 1},
-    lhe_ptr::Array{Cint, 1}, he_row_ptr::Array{Cint, 1},
-    he_val_ptr::Array{Cint, 1}, lhe_row::Array{Cint, 1},
-    he_row::Array{Cint, 1}, lhe_val::Array{Cint, 1},
-    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_csgreh_", cutest_lib), Void,
+    he_val::Array{Cdouble, 1}, byrows::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_csgreh_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cdouble},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}, Ptr{Cint},
     Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint},
@@ -974,20 +445,8 @@ end
 
 function chprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
-    vector::Array{Cdouble, 1}, result::Array{Cdouble, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_chprod_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, n, m, goth, x, y, vector, result)
-end
-
-function chprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
-    vector::Array{Cdouble, 1}, result::Array{Cdouble, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_chprod_", cutest_lib), Void,
+    vector::Array{Cdouble, 1}, result::Array{Cdouble, 1})
+  ccall(dlsym(cutest_lib, "cutest_chprod_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
     Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
     io_err, n, m, goth, x, y, vector, result)
@@ -995,20 +454,8 @@ end
 
 function chcprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
-    vector::Array{Cdouble, 1}, result::Array{Cdouble, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_chcprod_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
-    io_err, n, m, goth, x, y, vector, result)
-end
-
-function chcprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    goth::Array{Cint, 1}, x::Array{Cdouble, 1}, y::Array{Cdouble, 1},
-    vector::Array{Cdouble, 1}, result::Array{Cdouble, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_chcprod_", cutest_lib), Void,
+    vector::Array{Cdouble, 1}, result::Array{Cdouble, 1})
+  ccall(dlsym(cutest_lib, "cutest_chcprod_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
     Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
     io_err, n, m, goth, x, y, vector, result)
@@ -1017,48 +464,21 @@ end
 function cjprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
     gotj::Array{Cint, 1}, jtrans::Array{Cint, 1}, x::Array{Cdouble, 1},
     vector::Array{Cdouble, 1}, lvector::Array{Cint, 1},
-    result::Array{Cdouble, 1}, lresult::Array{Cint, 1},
-    libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cjprod_", cutest_lib), Void,
+    result::Array{Cdouble, 1}, lresult::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cjprod_"), Void,
     (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
     Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
     io_err, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
 end
 
-function cjprod(io_err::Array{Cint, 1}, n::Array{Cint, 1}, m::Array{Cint, 1},
-    gotj::Array{Cint, 1}, jtrans::Array{Cint, 1}, x::Array{Cdouble, 1},
-    vector::Array{Cdouble, 1}, lvector::Array{Cint, 1},
-    result::Array{Cdouble, 1}, lresult::Array{Cint, 1},
-    cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cjprod_", cutest_lib), Void,
-    (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble},
-    Ptr{Cdouble}, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-    io_err, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
-end
-
-function uterminate(io_err::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_uterminate_", cutest_lib), Void,
+function uterminate(io_err::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_uterminate_"), Void,
     (Ptr{Cint},),
     io_err)
 end
 
-function uterminate(io_err::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_uterminate_", cutest_lib), Void,
-    (Ptr{Cint},),
-    io_err)
-end
-
-function cterminate(io_err::Array{Cint, 1}, libname::ASCIIString)
-  cutest_lib = Libdl.dlopen(libname)
-  ccall(@dlsym("cutest_cterminate_", cutest_lib), Void,
-    (Ptr{Cint},),
-    io_err)
-end
-
-function cterminate(io_err::Array{Cint, 1}, cutest_lib::Ptr{Void})
-  ccall(@dlsym("cutest_cterminate_", cutest_lib), Void,
+function cterminate(io_err::Array{Cint, 1})
+  ccall(dlsym(cutest_lib, "cutest_cterminate_"), Void,
     (Ptr{Cint},),
     io_err)
 end

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -13,7 +13,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    usetup(io_err, input, out, io_buffer, n, x, x_l, x_u, cutest_lib)
+    usetup(io_err, input, out, io_buffer, n, x, x_l, x_u)
 
   - io_err:    [OUT] Array{Cint, 1}
   - input:     [IN] Array{Cint, 1}
@@ -23,20 +23,9 @@ Usage:
   - x:         [OUT] Array{Cdouble, 1}
   - x_l:       [OUT] Array{Cdouble, 1}
   - x_u:       [OUT] Array{Cdouble, 1}
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    x, x_l, x_u = usetup(input, out, io_buffer, n, cutest_lib)
 
-  - input:     [IN] Int
-  - out:       [IN] Int
-  - io_buffer: [IN] Int
-  - n:         [IN] Int
-  - x:         [OUT] Array{Float64, 1}
-  - x_l:       [OUT] Array{Float64, 1}
-  - x_u:       [OUT] Array{Float64, 1}
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    usetup!(input, out, io_buffer, n, x, x_l, x_u, cutest_lib)
+    x, x_l, x_u = usetup(input, out, io_buffer, n)
 
   - input:     [IN] Int
   - out:       [IN] Int
@@ -45,7 +34,16 @@ Usage:
   - x:         [OUT] Array{Float64, 1}
   - x_l:       [OUT] Array{Float64, 1}
   - x_u:       [OUT] Array{Float64, 1}
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    usetup!(input, out, io_buffer, n, x, x_l, x_u)
+
+  - input:     [IN] Int
+  - out:       [IN] Int
+  - io_buffer: [IN] Int
+  - n:         [IN] Int
+  - x:         [OUT] Array{Float64, 1}
+  - x_l:       [OUT] Array{Float64, 1}
+  - x_u:       [OUT] Array{Float64, 1}
 
 """
 usetup
@@ -65,7 +63,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    usetup(io_err, input, out, io_buffer, n, x, x_l, x_u, cutest_lib)
+    usetup(io_err, input, out, io_buffer, n, x, x_l, x_u)
 
   - io_err:    [OUT] Array{Cint, 1}
   - input:     [IN] Array{Cint, 1}
@@ -75,20 +73,9 @@ Usage:
   - x:         [OUT] Array{Cdouble, 1}
   - x_l:       [OUT] Array{Cdouble, 1}
   - x_u:       [OUT] Array{Cdouble, 1}
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    x, x_l, x_u = usetup(input, out, io_buffer, n, cutest_lib)
 
-  - input:     [IN] Int
-  - out:       [IN] Int
-  - io_buffer: [IN] Int
-  - n:         [IN] Int
-  - x:         [OUT] Array{Float64, 1}
-  - x_l:       [OUT] Array{Float64, 1}
-  - x_u:       [OUT] Array{Float64, 1}
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    usetup!(input, out, io_buffer, n, x, x_l, x_u, cutest_lib)
+    x, x_l, x_u = usetup(input, out, io_buffer, n)
 
   - input:     [IN] Int
   - out:       [IN] Int
@@ -97,7 +84,16 @@ Usage:
   - x:         [OUT] Array{Float64, 1}
   - x_l:       [OUT] Array{Float64, 1}
   - x_u:       [OUT] Array{Float64, 1}
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    usetup!(input, out, io_buffer, n, x, x_l, x_u)
+
+  - input:     [IN] Int
+  - out:       [IN] Int
+  - io_buffer: [IN] Int
+  - n:         [IN] Int
+  - x:         [OUT] Array{Float64, 1}
+  - x_l:       [OUT] Array{Float64, 1}
+  - x_u:       [OUT] Array{Float64, 1}
 
 """
 usetup!
@@ -120,7 +116,7 @@ errors. For more information, run the shell command
 Usage:
 
     csetup(io_err, input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn,
-linear, e_order, l_order, v_order, cutest_lib)
+linear, e_order, l_order, v_order)
 
   - io_err:    [OUT] Array{Cint, 1}
   - input:     [IN] Array{Cint, 1}
@@ -139,29 +135,9 @@ linear, e_order, l_order, v_order, cutest_lib)
   - e_order:   [IN] Array{Cint, 1}
   - l_order:   [IN] Array{Cint, 1}
   - v_order:   [IN] Array{Cint, 1}
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    x, x_l, x_u, y, c_l, c_u, equatn, linear = csetup(input, out, io_buffer, n, m, e_order, l_order, v_order, cutest_lib)
 
-  - input:     [IN] Int
-  - out:       [IN] Int
-  - io_buffer: [IN] Int
-  - n:         [IN] Int
-  - m:         [IN] Int
-  - x:         [OUT] Array{Float64, 1}
-  - x_l:       [OUT] Array{Float64, 1}
-  - x_u:       [OUT] Array{Float64, 1}
-  - y:         [OUT] Array{Float64, 1}
-  - c_l:       [OUT] Array{Float64, 1}
-  - c_u:       [OUT] Array{Float64, 1}
-  - equatn:    [OUT] Array{Bool, 1}
-  - linear:    [OUT] Array{Bool, 1}
-  - e_order:   [IN] Int
-  - l_order:   [IN] Int
-  - v_order:   [IN] Int
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    csetup!(input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn, linear, e_order, l_order, v_order, cutest_lib)
+    x, x_l, x_u, y, c_l, c_u, equatn, linear = csetup(input, out, io_buffer, n, m, e_order, l_order, v_order)
 
   - input:     [IN] Int
   - out:       [IN] Int
@@ -179,7 +155,25 @@ linear, e_order, l_order, v_order, cutest_lib)
   - e_order:   [IN] Int
   - l_order:   [IN] Int
   - v_order:   [IN] Int
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    csetup!(input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn, linear, e_order, l_order, v_order)
+
+  - input:     [IN] Int
+  - out:       [IN] Int
+  - io_buffer: [IN] Int
+  - n:         [IN] Int
+  - m:         [IN] Int
+  - x:         [OUT] Array{Float64, 1}
+  - x_l:       [OUT] Array{Float64, 1}
+  - x_u:       [OUT] Array{Float64, 1}
+  - y:         [OUT] Array{Float64, 1}
+  - c_l:       [OUT] Array{Float64, 1}
+  - c_u:       [OUT] Array{Float64, 1}
+  - equatn:    [OUT] Array{Bool, 1}
+  - linear:    [OUT] Array{Bool, 1}
+  - e_order:   [IN] Int
+  - l_order:   [IN] Int
+  - v_order:   [IN] Int
 
 """
 csetup
@@ -202,7 +196,7 @@ errors. For more information, run the shell command
 Usage:
 
     csetup(io_err, input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn,
-linear, e_order, l_order, v_order, cutest_lib)
+linear, e_order, l_order, v_order)
 
   - io_err:    [OUT] Array{Cint, 1}
   - input:     [IN] Array{Cint, 1}
@@ -221,29 +215,9 @@ linear, e_order, l_order, v_order, cutest_lib)
   - e_order:   [IN] Array{Cint, 1}
   - l_order:   [IN] Array{Cint, 1}
   - v_order:   [IN] Array{Cint, 1}
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    x, x_l, x_u, y, c_l, c_u, equatn, linear = csetup(input, out, io_buffer, n, m, e_order, l_order, v_order, cutest_lib)
 
-  - input:     [IN] Int
-  - out:       [IN] Int
-  - io_buffer: [IN] Int
-  - n:         [IN] Int
-  - m:         [IN] Int
-  - x:         [OUT] Array{Float64, 1}
-  - x_l:       [OUT] Array{Float64, 1}
-  - x_u:       [OUT] Array{Float64, 1}
-  - y:         [OUT] Array{Float64, 1}
-  - c_l:       [OUT] Array{Float64, 1}
-  - c_u:       [OUT] Array{Float64, 1}
-  - equatn:    [OUT] Array{Bool, 1}
-  - linear:    [OUT] Array{Bool, 1}
-  - e_order:   [IN] Int
-  - l_order:   [IN] Int
-  - v_order:   [IN] Int
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    csetup!(input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn, linear, e_order, l_order, v_order, cutest_lib)
+    x, x_l, x_u, y, c_l, c_u, equatn, linear = csetup(input, out, io_buffer, n, m, e_order, l_order, v_order)
 
   - input:     [IN] Int
   - out:       [IN] Int
@@ -261,7 +235,25 @@ linear, e_order, l_order, v_order, cutest_lib)
   - e_order:   [IN] Int
   - l_order:   [IN] Int
   - v_order:   [IN] Int
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    csetup!(input, out, io_buffer, n, m, x, x_l, x_u, y, c_l, c_u, equatn, linear, e_order, l_order, v_order)
+
+  - input:     [IN] Int
+  - out:       [IN] Int
+  - io_buffer: [IN] Int
+  - n:         [IN] Int
+  - m:         [IN] Int
+  - x:         [OUT] Array{Float64, 1}
+  - x_l:       [OUT] Array{Float64, 1}
+  - x_u:       [OUT] Array{Float64, 1}
+  - y:         [OUT] Array{Float64, 1}
+  - c_l:       [OUT] Array{Float64, 1}
+  - c_u:       [OUT] Array{Float64, 1}
+  - equatn:    [OUT] Array{Bool, 1}
+  - linear:    [OUT] Array{Bool, 1}
+  - e_order:   [IN] Int
+  - l_order:   [IN] Int
+  - v_order:   [IN] Int
 
 """
 csetup!
@@ -280,18 +272,17 @@ errors. For more information, run the shell command
 
 Usage:
 
-    udimen(io_err, input, n, cutest_lib)
+    udimen(io_err, input, n)
 
   - io_err:  [OUT] Array{Cint, 1}
   - input:   [IN] Array{Cint, 1}
   - n:       [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    n = udimen(input, cutest_lib)
+
+    n = udimen(input)
 
   - input:   [IN] Int
   - n:       [OUT] Int
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
 """
 udimen
@@ -312,16 +303,15 @@ errors. For more information, run the shell command
 
 Usage:
 
-    udimsh(io_err, nnzh, cutest_lib)
+    udimsh(io_err, nnzh)
 
   - io_err:  [OUT] Array{Cint, 1}
   - nnzh:    [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzh = udimsh(, cutest_lib)
+
+    nnzh = udimsh()
 
   - nnzh:    [OUT] Int
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
 """
 udimsh
@@ -344,20 +334,19 @@ errors. For more information, run the shell command
 
 Usage:
 
-    udimse(io_err, ne, he_val_ne, he_row_ne, cutest_lib)
+    udimse(io_err, ne, he_val_ne, he_row_ne)
 
   - io_err:    [OUT] Array{Cint, 1}
   - ne:        [OUT] Array{Cint, 1}
   - he_val_ne: [OUT] Array{Cint, 1}
   - he_row_ne: [OUT] Array{Cint, 1}
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    ne, he_val_ne, he_row_ne = udimse(, cutest_lib)
+
+    ne, he_val_ne, he_row_ne = udimse()
 
   - ne:        [OUT] Int
   - he_val_ne: [OUT] Int
   - he_row_ne: [OUT] Int
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
 """
 udimse
@@ -377,24 +366,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    uvartype(io_err, n, x_type, cutest_lib)
+    uvartype(io_err, n, x_type)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - x_type:  [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    x_type = uvartype(n, cutest_lib)
 
-  - n:       [IN] Int
-  - x_type:  [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    uvartype!(n, x_type, cutest_lib)
+    x_type = uvartype(n)
 
   - n:       [IN] Int
   - x_type:  [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    uvartype!(n, x_type)
+
+  - n:       [IN] Int
+  - x_type:  [OUT] Array{Int, 1}
 
 """
 uvartype
@@ -414,24 +401,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    uvartype(io_err, n, x_type, cutest_lib)
+    uvartype(io_err, n, x_type)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - x_type:  [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    x_type = uvartype(n, cutest_lib)
 
-  - n:       [IN] Int
-  - x_type:  [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    uvartype!(n, x_type, cutest_lib)
+    x_type = uvartype(n)
 
   - n:       [IN] Int
   - x_type:  [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    uvartype!(n, x_type)
+
+  - n:       [IN] Int
+  - x_type:  [OUT] Array{Int, 1}
 
 """
 uvartype!
@@ -449,27 +434,25 @@ errors. For more information, run the shell command
 
 Usage:
 
-    unames(io_err, n, pname, vname, cutest_lib)
+    unames(io_err, n, pname, vname)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - pname:   [OUT] Array{Cchar, 1}
   - vname:   [OUT] Array{Cchar, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    pname, vname = unames(n, cutest_lib)
 
-  - n:       [IN] Int
-  - pname:   [OUT] UInt8
-  - vname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    pname = unames!(n, vname, cutest_lib)
+    pname, vname = unames(n)
 
   - n:       [IN] Int
   - pname:   [OUT] UInt8
   - vname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    pname = unames!(n, vname)
+
+  - n:       [IN] Int
+  - pname:   [OUT] UInt8
+  - vname:   [OUT] Array{UInt8, 1}
 
 """
 unames
@@ -487,27 +470,25 @@ errors. For more information, run the shell command
 
 Usage:
 
-    unames(io_err, n, pname, vname, cutest_lib)
+    unames(io_err, n, pname, vname)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - pname:   [OUT] Array{Cchar, 1}
   - vname:   [OUT] Array{Cchar, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    pname, vname = unames(n, cutest_lib)
 
-  - n:       [IN] Int
-  - pname:   [OUT] UInt8
-  - vname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    pname = unames!(n, vname, cutest_lib)
+    pname, vname = unames(n)
 
   - n:       [IN] Int
   - pname:   [OUT] UInt8
   - vname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    pname = unames!(n, vname)
+
+  - n:       [IN] Int
+  - pname:   [OUT] UInt8
+  - vname:   [OUT] Array{UInt8, 1}
 
 """
 unames!
@@ -527,24 +508,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ureport(io_err, calls, time, cutest_lib)
+    ureport(io_err, calls, time)
 
   - io_err:  [OUT] Array{Cint, 1}
   - calls:   [OUT] Array{Cdouble, 1}
   - time:    [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    calls, time = ureport(, cutest_lib)
 
-  - calls:   [OUT] Array{Float64, 1}
-  - time:    [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ureport!(calls, time, cutest_lib)
+    calls, time = ureport()
 
   - calls:   [OUT] Array{Float64, 1}
   - time:    [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ureport!(calls, time)
+
+  - calls:   [OUT] Array{Float64, 1}
+  - time:    [OUT] Array{Float64, 1}
 
     calls, time = ureport(nlp)
 
@@ -576,24 +555,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ureport(io_err, calls, time, cutest_lib)
+    ureport(io_err, calls, time)
 
   - io_err:  [OUT] Array{Cint, 1}
   - calls:   [OUT] Array{Cdouble, 1}
   - time:    [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    calls, time = ureport(, cutest_lib)
 
-  - calls:   [OUT] Array{Float64, 1}
-  - time:    [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ureport!(calls, time, cutest_lib)
+    calls, time = ureport()
 
   - calls:   [OUT] Array{Float64, 1}
   - time:    [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ureport!(calls, time)
+
+  - calls:   [OUT] Array{Float64, 1}
+  - time:    [OUT] Array{Float64, 1}
 
     calls, time = ureport(nlp)
 
@@ -627,20 +604,19 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cdimen(io_err, input, n, m, cutest_lib)
+    cdimen(io_err, input, n, m)
 
   - io_err:  [OUT] Array{Cint, 1}
   - input:   [IN] Array{Cint, 1}
   - n:       [OUT] Array{Cint, 1}
   - m:       [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    n, m = cdimen(input, cutest_lib)
+
+    n, m = cdimen(input)
 
   - input:   [IN] Int
   - n:       [OUT] Int
   - m:       [OUT] Int
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
 """
 cdimen
@@ -664,16 +640,15 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cdimsj(io_err, nnzj, cutest_lib)
+    cdimsj(io_err, nnzj)
 
   - io_err:  [OUT] Array{Cint, 1}
   - nnzj:    [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzj = cdimsj(, cutest_lib)
+
+    nnzj = cdimsj()
 
   - nnzj:    [OUT] Int
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
 """
 cdimsj
@@ -696,16 +671,15 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cdimsh(io_err, nnzh, cutest_lib)
+    cdimsh(io_err, nnzh)
 
   - io_err:  [OUT] Array{Cint, 1}
   - nnzh:    [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzh = cdimsh(, cutest_lib)
+
+    nnzh = cdimsh()
 
   - nnzh:    [OUT] Int
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
 """
 cdimsh
@@ -730,20 +704,19 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cdimse(io_err, ne, he_val_ne, he_row_ne, cutest_lib)
+    cdimse(io_err, ne, he_val_ne, he_row_ne)
 
   - io_err:    [OUT] Array{Cint, 1}
   - ne:        [OUT] Array{Cint, 1}
   - he_val_ne: [OUT] Array{Cint, 1}
   - he_row_ne: [OUT] Array{Cint, 1}
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    ne, he_val_ne, he_row_ne = cdimse(, cutest_lib)
+
+    ne, he_val_ne, he_row_ne = cdimse()
 
   - ne:        [OUT] Int
   - he_val_ne: [OUT] Int
   - he_row_ne: [OUT] Int
-  - cutest_lib:   [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
 """
 cdimse
@@ -751,14 +724,14 @@ cdimse
 """# cstats
     cstats(io_err, nonlinear_variables_objective,
 nonlinear_variables_constraints, equality_constraints,
-linear_constraints, cutest_lib)
+linear_constraints)
 
   - io_err:                          [OUT] Array{Cint, 1}
   - nonlinear_variables_objective:   [OUT] Array{Cint, 1}
   - nonlinear_variables_constraints: [OUT] Array{Cint, 1}
   - equality_constraints:            [OUT] Array{Cint, 1}
   - linear_constraints:              [OUT] Array{Cint, 1}
-  - cutest_lib:                         [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
 
 """
 cstats
@@ -780,24 +753,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cvartype(io_err, n, x_type, cutest_lib)
+    cvartype(io_err, n, x_type)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - x_type:  [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    x_type = cvartype(n, cutest_lib)
 
-  - n:       [IN] Int
-  - x_type:  [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cvartype!(n, x_type, cutest_lib)
+    x_type = cvartype(n)
 
   - n:       [IN] Int
   - x_type:  [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cvartype!(n, x_type)
+
+  - n:       [IN] Int
+  - x_type:  [OUT] Array{Int, 1}
 
 """
 cvartype
@@ -819,24 +790,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cvartype(io_err, n, x_type, cutest_lib)
+    cvartype(io_err, n, x_type)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - x_type:  [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    x_type = cvartype(n, cutest_lib)
 
-  - n:       [IN] Int
-  - x_type:  [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cvartype!(n, x_type, cutest_lib)
+    x_type = cvartype(n)
 
   - n:       [IN] Int
   - x_type:  [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cvartype!(n, x_type)
+
+  - n:       [IN] Int
+  - x_type:  [OUT] Array{Int, 1}
 
 """
 cvartype!
@@ -857,7 +826,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cnames(io_err, n, m, pname, vname, cname, cutest_lib)
+    cnames(io_err, n, m, pname, vname, cname)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -865,25 +834,23 @@ Usage:
   - pname:   [OUT] Array{Cchar, 1}
   - vname:   [OUT] Array{Cchar, 1}
   - cname:   [OUT] Array{Cchar, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    pname, vname, cname = cnames(n, m, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - pname:   [OUT] UInt8
-  - vname:   [OUT] Array{UInt8, 1}
-  - cname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    pname = cnames!(n, m, vname, cname, cutest_lib)
+    pname, vname, cname = cnames(n, m)
 
   - n:       [IN] Int
   - m:       [IN] Int
   - pname:   [OUT] UInt8
   - vname:   [OUT] Array{UInt8, 1}
   - cname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    pname = cnames!(n, m, vname, cname)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - pname:   [OUT] UInt8
+  - vname:   [OUT] Array{UInt8, 1}
+  - cname:   [OUT] Array{UInt8, 1}
 
     pname, vname, cname = cnames(nlp)
 
@@ -918,7 +885,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cnames(io_err, n, m, pname, vname, cname, cutest_lib)
+    cnames(io_err, n, m, pname, vname, cname)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -926,25 +893,23 @@ Usage:
   - pname:   [OUT] Array{Cchar, 1}
   - vname:   [OUT] Array{Cchar, 1}
   - cname:   [OUT] Array{Cchar, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    pname, vname, cname = cnames(n, m, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - pname:   [OUT] UInt8
-  - vname:   [OUT] Array{UInt8, 1}
-  - cname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    pname = cnames!(n, m, vname, cname, cutest_lib)
+    pname, vname, cname = cnames(n, m)
 
   - n:       [IN] Int
   - m:       [IN] Int
   - pname:   [OUT] UInt8
   - vname:   [OUT] Array{UInt8, 1}
   - cname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    pname = cnames!(n, m, vname, cname)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - pname:   [OUT] UInt8
+  - vname:   [OUT] Array{UInt8, 1}
+  - cname:   [OUT] Array{UInt8, 1}
 
     pname, vname, cname = cnames(nlp)
 
@@ -980,24 +945,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    creport(io_err, calls, time, cutest_lib)
+    creport(io_err, calls, time)
 
   - io_err:  [OUT] Array{Cint, 1}
   - calls:   [OUT] Array{Cdouble, 1}
   - time:    [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    calls, time = creport(, cutest_lib)
 
-  - calls:   [OUT] Array{Float64, 1}
-  - time:    [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    creport!(calls, time, cutest_lib)
+    calls, time = creport()
 
   - calls:   [OUT] Array{Float64, 1}
   - time:    [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    creport!(calls, time)
+
+  - calls:   [OUT] Array{Float64, 1}
+  - time:    [OUT] Array{Float64, 1}
 
     calls, time = creport(nlp)
 
@@ -1031,24 +994,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    creport(io_err, calls, time, cutest_lib)
+    creport(io_err, calls, time)
 
   - io_err:  [OUT] Array{Cint, 1}
   - calls:   [OUT] Array{Cdouble, 1}
   - time:    [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    calls, time = creport(, cutest_lib)
 
-  - calls:   [OUT] Array{Float64, 1}
-  - time:    [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    creport!(calls, time, cutest_lib)
+    calls, time = creport()
 
   - calls:   [OUT] Array{Float64, 1}
   - time:    [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    creport!(calls, time)
+
+  - calls:   [OUT] Array{Float64, 1}
+  - time:    [OUT] Array{Float64, 1}
 
     calls, time = creport(nlp)
 
@@ -1081,24 +1042,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    connames(io_err, m, cname, cutest_lib)
+    connames(io_err, m, cname)
 
   - io_err:  [OUT] Array{Cint, 1}
   - m:       [IN] Array{Cint, 1}
   - cname:   [OUT] Array{Cchar, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    cname = connames(m, cutest_lib)
 
-  - m:       [IN] Int
-  - cname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    connames!(m, cname, cutest_lib)
+    cname = connames(m)
 
   - m:       [IN] Int
   - cname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    connames!(m, cname)
+
+  - m:       [IN] Int
+  - cname:   [OUT] Array{UInt8, 1}
 
     cname = connames(nlp)
 
@@ -1129,24 +1088,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    connames(io_err, m, cname, cutest_lib)
+    connames(io_err, m, cname)
 
   - io_err:  [OUT] Array{Cint, 1}
   - m:       [IN] Array{Cint, 1}
   - cname:   [OUT] Array{Cchar, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    cname = connames(m, cutest_lib)
 
-  - m:       [IN] Int
-  - cname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    connames!(m, cname, cutest_lib)
+    cname = connames(m)
 
   - m:       [IN] Int
   - cname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    connames!(m, cname)
+
+  - m:       [IN] Int
+  - cname:   [OUT] Array{UInt8, 1}
 
     cname = connames(nlp)
 
@@ -1178,18 +1135,17 @@ errors. For more information, run the shell command
 
 Usage:
 
-    pname(io_err, input, pname, cutest_lib)
+    pname(io_err, input, pname)
 
   - io_err:  [OUT] Array{Cint, 1}
   - input:   [IN] Array{Cint, 1}
   - pname:   [OUT] Array{Cchar, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    pname = pname(input, cutest_lib)
+
+    pname = pname(input)
 
   - input:   [IN] Int
   - pname:   [OUT] UInt8
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
     pname = pname(nlp, input)
 
@@ -1215,16 +1171,15 @@ errors. For more information, run the shell command
 
 Usage:
 
-    probname(io_err, pname, cutest_lib)
+    probname(io_err, pname)
 
   - io_err:  [OUT] Array{Cint, 1}
   - pname:   [OUT] Array{Cchar, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    pname = probname(, cutest_lib)
+
+    pname = probname()
 
   - pname:   [OUT] UInt8
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
     pname = probname(nlp)
 
@@ -1250,24 +1205,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    varnames(io_err, n, vname, cutest_lib)
+    varnames(io_err, n, vname)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - vname:   [OUT] Array{Cchar, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    vname = varnames(n, cutest_lib)
 
-  - n:       [IN] Int
-  - vname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    varnames!(n, vname, cutest_lib)
+    vname = varnames(n)
 
   - n:       [IN] Int
   - vname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    varnames!(n, vname)
+
+  - n:       [IN] Int
+  - vname:   [OUT] Array{UInt8, 1}
 
 """
 varnames
@@ -1288,24 +1241,22 @@ errors. For more information, run the shell command
 
 Usage:
 
-    varnames(io_err, n, vname, cutest_lib)
+    varnames(io_err, n, vname)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - vname:   [OUT] Array{Cchar, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    vname = varnames(n, cutest_lib)
 
-  - n:       [IN] Int
-  - vname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    varnames!(n, vname, cutest_lib)
+    vname = varnames(n)
 
   - n:       [IN] Int
   - vname:   [OUT] Array{UInt8, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    varnames!(n, vname)
+
+  - n:       [IN] Int
+  - vname:   [OUT] Array{UInt8, 1}
 
 """
 varnames!
@@ -1324,20 +1275,19 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ufn(io_err, n, x, f, cutest_lib)
+    ufn(io_err, n, x, f)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - x:       [IN] Array{Cdouble, 1}
   - f:       [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f = ufn(n, x, cutest_lib)
+
+    f = ufn(n, x)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - f:       [OUT] Float64
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
     f = ufn(nlp, x)
 
@@ -1362,27 +1312,25 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ugr(io_err, n, x, g, cutest_lib)
+    ugr(io_err, n, x, g)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - x:       [IN] Array{Cdouble, 1}
   - g:       [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g = ugr(n, x, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - g:       [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ugr!(n, x, g, cutest_lib)
+    g = ugr(n, x)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - g:       [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ugr!(n, x, g)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - g:       [OUT] Array{Float64, 1}
 
     g = ugr(nlp, x)
 
@@ -1413,27 +1361,25 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ugr(io_err, n, x, g, cutest_lib)
+    ugr(io_err, n, x, g)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - x:       [IN] Array{Cdouble, 1}
   - g:       [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g = ugr(n, x, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - g:       [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ugr!(n, x, g, cutest_lib)
+    g = ugr(n, x)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - g:       [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ugr!(n, x, g)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - g:       [OUT] Array{Float64, 1}
 
     g = ugr(nlp, x)
 
@@ -1465,7 +1411,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    uofg(io_err, n, x, f, g, grad, cutest_lib)
+    uofg(io_err, n, x, f, g, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -1473,25 +1419,23 @@ Usage:
   - f:       [OUT] Array{Cdouble, 1}
   - g:       [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f, g = uofg(n, x, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - f:       [OUT] Float64
-  - g:       [OUT] Array{Float64, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    f = uofg!(n, x, g, grad, cutest_lib)
+    f, g = uofg(n, x, grad)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - f:       [OUT] Float64
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    f = uofg!(n, x, g, grad)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - f:       [OUT] Float64
+  - g:       [OUT] Array{Float64, 1}
+  - grad:    [IN] Bool
 
     f, g = uofg(nlp, x, grad)
 
@@ -1527,7 +1471,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    uofg(io_err, n, x, f, g, grad, cutest_lib)
+    uofg(io_err, n, x, f, g, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -1535,25 +1479,23 @@ Usage:
   - f:       [OUT] Array{Cdouble, 1}
   - g:       [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f, g = uofg(n, x, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - f:       [OUT] Float64
-  - g:       [OUT] Array{Float64, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    f = uofg!(n, x, g, grad, cutest_lib)
+    f, g = uofg(n, x, grad)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - f:       [OUT] Float64
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    f = uofg!(n, x, g, grad)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - f:       [OUT] Float64
+  - g:       [OUT] Array{Float64, 1}
+  - grad:    [IN] Bool
 
     f, g = uofg(nlp, x, grad)
 
@@ -1590,7 +1532,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ubandh(io_err, n, x, semibandwidth, h_band, lbandh, max_semibandwidth, cutest_lib)
+    ubandh(io_err, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
 
   - io_err:            [OUT] Array{Cint, 1}
   - n:                 [IN] Array{Cint, 1}
@@ -1599,19 +1541,9 @@ Usage:
   - h_band:            [OUT] Array{Cdouble, 2}
   - lbandh:            [IN] Array{Cint, 1}
   - max_semibandwidth: [OUT] Array{Cint, 1}
-  - cutest_lib:           [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    h_band, max_semibandwidth = ubandh(n, x, semibandwidth, lbandh, cutest_lib)
 
-  - n:                 [IN] Int
-  - x:                 [IN] Array{Float64, 1}
-  - semibandwidth:     [IN] Int
-  - h_band:            [OUT] Array{Float64, 2}
-  - lbandh:            [IN] Int
-  - max_semibandwidth: [OUT] Int
-  - cutest_lib:           [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    max_semibandwidth = ubandh!(n, x, semibandwidth, h_band, lbandh, cutest_lib)
+    h_band, max_semibandwidth = ubandh(n, x, semibandwidth, lbandh)
 
   - n:                 [IN] Int
   - x:                 [IN] Array{Float64, 1}
@@ -1619,7 +1551,15 @@ Usage:
   - h_band:            [OUT] Array{Float64, 2}
   - lbandh:            [IN] Int
   - max_semibandwidth: [OUT] Int
-  - cutest_lib:           [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    max_semibandwidth = ubandh!(n, x, semibandwidth, h_band, lbandh)
+
+  - n:                 [IN] Int
+  - x:                 [IN] Array{Float64, 1}
+  - semibandwidth:     [IN] Int
+  - h_band:            [OUT] Array{Float64, 2}
+  - lbandh:            [IN] Int
+  - max_semibandwidth: [OUT] Int
 
     h_band, max_semibandwidth = ubandh(nlp, x, semibandwidth, lbandh)
 
@@ -1658,7 +1598,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ubandh(io_err, n, x, semibandwidth, h_band, lbandh, max_semibandwidth, cutest_lib)
+    ubandh(io_err, n, x, semibandwidth, h_band, lbandh, max_semibandwidth)
 
   - io_err:            [OUT] Array{Cint, 1}
   - n:                 [IN] Array{Cint, 1}
@@ -1667,19 +1607,9 @@ Usage:
   - h_band:            [OUT] Array{Cdouble, 2}
   - lbandh:            [IN] Array{Cint, 1}
   - max_semibandwidth: [OUT] Array{Cint, 1}
-  - cutest_lib:           [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    h_band, max_semibandwidth = ubandh(n, x, semibandwidth, lbandh, cutest_lib)
 
-  - n:                 [IN] Int
-  - x:                 [IN] Array{Float64, 1}
-  - semibandwidth:     [IN] Int
-  - h_band:            [OUT] Array{Float64, 2}
-  - lbandh:            [IN] Int
-  - max_semibandwidth: [OUT] Int
-  - cutest_lib:           [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    max_semibandwidth = ubandh!(n, x, semibandwidth, h_band, lbandh, cutest_lib)
+    h_band, max_semibandwidth = ubandh(n, x, semibandwidth, lbandh)
 
   - n:                 [IN] Int
   - x:                 [IN] Array{Float64, 1}
@@ -1687,7 +1617,15 @@ Usage:
   - h_band:            [OUT] Array{Float64, 2}
   - lbandh:            [IN] Int
   - max_semibandwidth: [OUT] Int
-  - cutest_lib:           [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    max_semibandwidth = ubandh!(n, x, semibandwidth, h_band, lbandh)
+
+  - n:                 [IN] Int
+  - x:                 [IN] Array{Float64, 1}
+  - semibandwidth:     [IN] Int
+  - h_band:            [OUT] Array{Float64, 2}
+  - lbandh:            [IN] Int
+  - max_semibandwidth: [OUT] Int
 
     h_band, max_semibandwidth = ubandh(nlp, x, semibandwidth, lbandh)
 
@@ -1725,30 +1663,28 @@ errors. For more information, run the shell command
 
 Usage:
 
-    udh(io_err, n, x, lh1, h, cutest_lib)
+    udh(io_err, n, x, lh1, h)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - x:       [IN] Array{Cdouble, 1}
   - lh1:     [IN] Array{Cint, 1}
   - h:       [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    h = udh(n, x, lh1, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - lh1:     [IN] Int
-  - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    udh!(n, x, lh1, h, cutest_lib)
+    h = udh(n, x, lh1)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    udh!(n, x, lh1, h)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - lh1:     [IN] Int
+  - h:       [OUT] Array{Float64, 2}
 
     h = udh(nlp, x, lh1)
 
@@ -1782,30 +1718,28 @@ errors. For more information, run the shell command
 
 Usage:
 
-    udh(io_err, n, x, lh1, h, cutest_lib)
+    udh(io_err, n, x, lh1, h)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
   - x:       [IN] Array{Cdouble, 1}
   - lh1:     [IN] Array{Cint, 1}
   - h:       [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    h = udh(n, x, lh1, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - lh1:     [IN] Int
-  - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    udh!(n, x, lh1, h, cutest_lib)
+    h = udh(n, x, lh1)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    udh!(n, x, lh1, h)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - lh1:     [IN] Int
+  - h:       [OUT] Array{Float64, 2}
 
     h = udh(nlp, x, lh1)
 
@@ -1840,7 +1774,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ush(io_err, n, x, nnzh, lh, h_val, h_row, h_col, cutest_lib)
+    ush(io_err, n, x, nnzh, lh, h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -1850,20 +1784,9 @@ Usage:
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzh, h_val, h_row, h_col = ush(n, x, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzh = ush!(n, x, lh, h_val, h_row, h_col, cutest_lib)
+    nnzh, h_val, h_row, h_col = ush(n, x, lh)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
@@ -1872,7 +1795,16 @@ Usage:
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzh = ush!(n, x, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     nnzh, h_val, h_row, h_col = ush(nlp, x)
 
@@ -1911,7 +1843,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ush(io_err, n, x, nnzh, lh, h_val, h_row, h_col, cutest_lib)
+    ush(io_err, n, x, nnzh, lh, h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -1921,20 +1853,9 @@ Usage:
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzh, h_val, h_row, h_col = ush(n, x, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzh = ush!(n, x, lh, h_val, h_row, h_col, cutest_lib)
+    nnzh, h_val, h_row, h_col = ush(n, x, lh)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
@@ -1943,7 +1864,16 @@ Usage:
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzh = ush!(n, x, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     nnzh, h_val, h_row, h_col = ush(nlp, x)
 
@@ -1984,7 +1914,7 @@ errors. For more information, run the shell command
 Usage:
 
     ueh(io_err, n, x, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
-lhe_val, he_val, byrows, cutest_lib)
+lhe_val, he_val, byrows)
 
   - io_err:     [OUT] Array{Cint, 1}
   - n:          [IN] Array{Cint, 1}
@@ -1998,24 +1928,9 @@ lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Array{Cint, 1}
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    ne, he_row_ptr, he_val_ptr, he_row, he_val = ueh(n, x, lhe_ptr, lhe_row, lhe_val, byrows, cutest_lib)
 
-  - n:          [IN] Int
-  - x:          [IN] Array{Float64, 1}
-  - ne:         [OUT] Int
-  - lhe_ptr:    [IN] Int
-  - he_row_ptr: [OUT] Array{Int, 1}
-  - he_val_ptr: [OUT] Array{Int, 1}
-  - lhe_row:    [IN] Int
-  - he_row:     [OUT] Array{Int, 1}
-  - lhe_val:    [IN] Int
-  - he_val:     [OUT] Array{Float64, 1}
-  - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ne = ueh!(n, x, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows, cutest_lib)
+    ne, he_row_ptr, he_val_ptr, he_row, he_val = ueh(n, x, lhe_ptr, lhe_row, lhe_val, byrows)
 
   - n:          [IN] Int
   - x:          [IN] Array{Float64, 1}
@@ -2028,7 +1943,20 @@ lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Int
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ne = ueh!(n, x, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+
+  - n:          [IN] Int
+  - x:          [IN] Array{Float64, 1}
+  - ne:         [OUT] Int
+  - lhe_ptr:    [IN] Int
+  - he_row_ptr: [OUT] Array{Int, 1}
+  - he_val_ptr: [OUT] Array{Int, 1}
+  - lhe_row:    [IN] Int
+  - he_row:     [OUT] Array{Int, 1}
+  - lhe_val:    [IN] Int
+  - he_val:     [OUT] Array{Float64, 1}
+  - byrows:     [IN] Bool
 
     ne, he_row_ptr, he_val_ptr, he_row, he_val = ueh(nlp, x, lhe_ptr, lhe_row, lhe_val, byrows)
 
@@ -2079,7 +2007,7 @@ errors. For more information, run the shell command
 Usage:
 
     ueh(io_err, n, x, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
-lhe_val, he_val, byrows, cutest_lib)
+lhe_val, he_val, byrows)
 
   - io_err:     [OUT] Array{Cint, 1}
   - n:          [IN] Array{Cint, 1}
@@ -2093,24 +2021,9 @@ lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Array{Cint, 1}
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    ne, he_row_ptr, he_val_ptr, he_row, he_val = ueh(n, x, lhe_ptr, lhe_row, lhe_val, byrows, cutest_lib)
 
-  - n:          [IN] Int
-  - x:          [IN] Array{Float64, 1}
-  - ne:         [OUT] Int
-  - lhe_ptr:    [IN] Int
-  - he_row_ptr: [OUT] Array{Int, 1}
-  - he_val_ptr: [OUT] Array{Int, 1}
-  - lhe_row:    [IN] Int
-  - he_row:     [OUT] Array{Int, 1}
-  - lhe_val:    [IN] Int
-  - he_val:     [OUT] Array{Float64, 1}
-  - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ne = ueh!(n, x, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows, cutest_lib)
+    ne, he_row_ptr, he_val_ptr, he_row, he_val = ueh(n, x, lhe_ptr, lhe_row, lhe_val, byrows)
 
   - n:          [IN] Int
   - x:          [IN] Array{Float64, 1}
@@ -2123,7 +2036,20 @@ lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Int
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ne = ueh!(n, x, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+
+  - n:          [IN] Int
+  - x:          [IN] Array{Float64, 1}
+  - ne:         [OUT] Int
+  - lhe_ptr:    [IN] Int
+  - he_row_ptr: [OUT] Array{Int, 1}
+  - he_val_ptr: [OUT] Array{Int, 1}
+  - lhe_row:    [IN] Int
+  - he_row:     [OUT] Array{Int, 1}
+  - lhe_val:    [IN] Int
+  - he_val:     [OUT] Array{Float64, 1}
+  - byrows:     [IN] Bool
 
     ne, he_row_ptr, he_val_ptr, he_row, he_val = ueh(nlp, x, lhe_ptr, lhe_row, lhe_val, byrows)
 
@@ -2172,7 +2098,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ugrdh(io_err, n, x, g, lh1, h, cutest_lib)
+    ugrdh(io_err, n, x, g, lh1, h)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -2180,25 +2106,23 @@ Usage:
   - g:       [OUT] Array{Cdouble, 1}
   - lh1:     [IN] Array{Cint, 1}
   - h:       [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g, h = ugrdh(n, x, lh1, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - g:       [OUT] Array{Float64, 1}
-  - lh1:     [IN] Int
-  - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ugrdh!(n, x, g, lh1, h, cutest_lib)
+    g, h = ugrdh(n, x, lh1)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - g:       [OUT] Array{Float64, 1}
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ugrdh!(n, x, g, lh1, h)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - g:       [OUT] Array{Float64, 1}
+  - lh1:     [IN] Int
+  - h:       [OUT] Array{Float64, 2}
 
     g, h = ugrdh(nlp, x, lh1)
 
@@ -2235,7 +2159,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ugrdh(io_err, n, x, g, lh1, h, cutest_lib)
+    ugrdh(io_err, n, x, g, lh1, h)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -2243,25 +2167,23 @@ Usage:
   - g:       [OUT] Array{Cdouble, 1}
   - lh1:     [IN] Array{Cint, 1}
   - h:       [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g, h = ugrdh(n, x, lh1, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - g:       [OUT] Array{Float64, 1}
-  - lh1:     [IN] Int
-  - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ugrdh!(n, x, g, lh1, h, cutest_lib)
+    g, h = ugrdh(n, x, lh1)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - g:       [OUT] Array{Float64, 1}
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ugrdh!(n, x, g, lh1, h)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - g:       [OUT] Array{Float64, 1}
+  - lh1:     [IN] Int
+  - h:       [OUT] Array{Float64, 2}
 
     g, h = ugrdh(nlp, x, lh1)
 
@@ -2298,7 +2220,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ugrsh(io_err, n, x, g, nnzh, lh, h_val, h_row, h_col, cutest_lib)
+    ugrsh(io_err, n, x, g, nnzh, lh, h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -2309,21 +2231,9 @@ Usage:
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g, nnzh, h_val, h_row, h_col = ugrsh(n, x, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - g:       [OUT] Array{Float64, 1}
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzh = ugrsh!(n, x, g, lh, h_val, h_row, h_col, cutest_lib)
+    g, nnzh, h_val, h_row, h_col = ugrsh(n, x, lh)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
@@ -2333,7 +2243,17 @@ Usage:
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzh = ugrsh!(n, x, g, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - g:       [OUT] Array{Float64, 1}
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     g, nnzh, h_val, h_row, h_col = ugrsh(nlp, x)
 
@@ -2374,7 +2294,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ugrsh(io_err, n, x, g, nnzh, lh, h_val, h_row, h_col, cutest_lib)
+    ugrsh(io_err, n, x, g, nnzh, lh, h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -2385,21 +2305,9 @@ Usage:
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g, nnzh, h_val, h_row, h_col = ugrsh(n, x, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - g:       [OUT] Array{Float64, 1}
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzh = ugrsh!(n, x, g, lh, h_val, h_row, h_col, cutest_lib)
+    g, nnzh, h_val, h_row, h_col = ugrsh(n, x, lh)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
@@ -2409,7 +2317,17 @@ Usage:
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzh = ugrsh!(n, x, g, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - g:       [OUT] Array{Float64, 1}
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     g, nnzh, h_val, h_row, h_col = ugrsh(nlp, x)
 
@@ -2453,7 +2371,7 @@ errors. For more information, run the shell command
 Usage:
 
     ugreh(io_err, n, x, g, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
-lhe_val, he_val, byrows, cutest_lib)
+lhe_val, he_val, byrows)
 
   - io_err:     [OUT] Array{Cint, 1}
   - n:          [IN] Array{Cint, 1}
@@ -2468,25 +2386,9 @@ lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Array{Cint, 1}
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g, ne, he_row_ptr, he_val_ptr, he_row, he_val = ugreh(n, x, lhe_ptr, lhe_row, lhe_val, byrows, cutest_lib)
 
-  - n:          [IN] Int
-  - x:          [IN] Array{Float64, 1}
-  - g:          [OUT] Array{Float64, 1}
-  - ne:         [OUT] Int
-  - lhe_ptr:    [IN] Int
-  - he_row_ptr: [OUT] Array{Int, 1}
-  - he_val_ptr: [OUT] Array{Int, 1}
-  - lhe_row:    [IN] Int
-  - he_row:     [OUT] Array{Int, 1}
-  - lhe_val:    [IN] Int
-  - he_val:     [OUT] Array{Float64, 1}
-  - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ne = ugreh!(n, x, g, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows, cutest_lib)
+    g, ne, he_row_ptr, he_val_ptr, he_row, he_val = ugreh(n, x, lhe_ptr, lhe_row, lhe_val, byrows)
 
   - n:          [IN] Int
   - x:          [IN] Array{Float64, 1}
@@ -2500,7 +2402,21 @@ lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Int
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ne = ugreh!(n, x, g, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+
+  - n:          [IN] Int
+  - x:          [IN] Array{Float64, 1}
+  - g:          [OUT] Array{Float64, 1}
+  - ne:         [OUT] Int
+  - lhe_ptr:    [IN] Int
+  - he_row_ptr: [OUT] Array{Int, 1}
+  - he_val_ptr: [OUT] Array{Int, 1}
+  - lhe_row:    [IN] Int
+  - he_row:     [OUT] Array{Int, 1}
+  - lhe_val:    [IN] Int
+  - he_val:     [OUT] Array{Float64, 1}
+  - byrows:     [IN] Bool
 
     g, ne, he_row_ptr, he_val_ptr, he_row, he_val = ugreh(nlp, x, lhe_ptr, lhe_row, lhe_val, byrows)
 
@@ -2554,7 +2470,7 @@ errors. For more information, run the shell command
 Usage:
 
     ugreh(io_err, n, x, g, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row,
-lhe_val, he_val, byrows, cutest_lib)
+lhe_val, he_val, byrows)
 
   - io_err:     [OUT] Array{Cint, 1}
   - n:          [IN] Array{Cint, 1}
@@ -2569,25 +2485,9 @@ lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Array{Cint, 1}
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g, ne, he_row_ptr, he_val_ptr, he_row, he_val = ugreh(n, x, lhe_ptr, lhe_row, lhe_val, byrows, cutest_lib)
 
-  - n:          [IN] Int
-  - x:          [IN] Array{Float64, 1}
-  - g:          [OUT] Array{Float64, 1}
-  - ne:         [OUT] Int
-  - lhe_ptr:    [IN] Int
-  - he_row_ptr: [OUT] Array{Int, 1}
-  - he_val_ptr: [OUT] Array{Int, 1}
-  - lhe_row:    [IN] Int
-  - he_row:     [OUT] Array{Int, 1}
-  - lhe_val:    [IN] Int
-  - he_val:     [OUT] Array{Float64, 1}
-  - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ne = ugreh!(n, x, g, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows, cutest_lib)
+    g, ne, he_row_ptr, he_val_ptr, he_row, he_val = ugreh(n, x, lhe_ptr, lhe_row, lhe_val, byrows)
 
   - n:          [IN] Int
   - x:          [IN] Array{Float64, 1}
@@ -2601,7 +2501,21 @@ lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Int
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ne = ugreh!(n, x, g, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+
+  - n:          [IN] Int
+  - x:          [IN] Array{Float64, 1}
+  - g:          [OUT] Array{Float64, 1}
+  - ne:         [OUT] Int
+  - lhe_ptr:    [IN] Int
+  - he_row_ptr: [OUT] Array{Int, 1}
+  - he_val_ptr: [OUT] Array{Int, 1}
+  - lhe_row:    [IN] Int
+  - he_row:     [OUT] Array{Int, 1}
+  - lhe_val:    [IN] Int
+  - he_val:     [OUT] Array{Float64, 1}
+  - byrows:     [IN] Bool
 
     g, ne, he_row_ptr, he_val_ptr, he_row, he_val = ugreh(nlp, x, lhe_ptr, lhe_row, lhe_val, byrows)
 
@@ -2651,7 +2565,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    uhprod(io_err, n, goth, x, vector, result, cutest_lib)
+    uhprod(io_err, n, goth, x, vector, result)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -2659,25 +2573,23 @@ Usage:
   - x:       [IN] Array{Cdouble, 1}
   - vector:  [IN] Array{Cdouble, 1}
   - result:  [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    result = uhprod(n, goth, x, vector, cutest_lib)
 
-  - n:       [IN] Int
-  - goth:    [IN] Bool
-  - x:       [IN] Array{Float64, 1}
-  - vector:  [IN] Array{Float64, 1}
-  - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    uhprod!(n, goth, x, vector, result, cutest_lib)
+    result = uhprod(n, goth, x, vector)
 
   - n:       [IN] Int
   - goth:    [IN] Bool
   - x:       [IN] Array{Float64, 1}
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    uhprod!(n, goth, x, vector, result)
+
+  - n:       [IN] Int
+  - goth:    [IN] Bool
+  - x:       [IN] Array{Float64, 1}
+  - vector:  [IN] Array{Float64, 1}
+  - result:  [OUT] Array{Float64, 1}
 
     result = uhprod(nlp, goth, x, vector)
 
@@ -2713,7 +2625,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    uhprod(io_err, n, goth, x, vector, result, cutest_lib)
+    uhprod(io_err, n, goth, x, vector, result)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -2721,25 +2633,23 @@ Usage:
   - x:       [IN] Array{Cdouble, 1}
   - vector:  [IN] Array{Cdouble, 1}
   - result:  [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    result = uhprod(n, goth, x, vector, cutest_lib)
 
-  - n:       [IN] Int
-  - goth:    [IN] Bool
-  - x:       [IN] Array{Float64, 1}
-  - vector:  [IN] Array{Float64, 1}
-  - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    uhprod!(n, goth, x, vector, result, cutest_lib)
+    result = uhprod(n, goth, x, vector)
 
   - n:       [IN] Int
   - goth:    [IN] Bool
   - x:       [IN] Array{Float64, 1}
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    uhprod!(n, goth, x, vector, result)
+
+  - n:       [IN] Int
+  - goth:    [IN] Bool
+  - x:       [IN] Array{Float64, 1}
+  - vector:  [IN] Array{Float64, 1}
+  - result:  [OUT] Array{Float64, 1}
 
     result = uhprod(nlp, goth, x, vector)
 
@@ -2777,7 +2687,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cfn(io_err, n, m, x, f, c, cutest_lib)
+    cfn(io_err, n, m, x, f, c)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -2785,25 +2695,23 @@ Usage:
   - x:       [IN] Array{Cdouble, 1}
   - f:       [OUT] Array{Cdouble, 1}
   - c:       [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f, c = cfn(n, m, x, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - f:       [OUT] Float64
-  - c:       [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    f = cfn!(n, m, x, c, cutest_lib)
+    f, c = cfn(n, m, x)
 
   - n:       [IN] Int
   - m:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - f:       [OUT] Float64
   - c:       [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    f = cfn!(n, m, x, c)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - f:       [OUT] Float64
+  - c:       [OUT] Array{Float64, 1}
 
     f, c = cfn(nlp, x)
 
@@ -2839,7 +2747,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cfn(io_err, n, m, x, f, c, cutest_lib)
+    cfn(io_err, n, m, x, f, c)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -2847,25 +2755,23 @@ Usage:
   - x:       [IN] Array{Cdouble, 1}
   - f:       [OUT] Array{Cdouble, 1}
   - c:       [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f, c = cfn(n, m, x, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - f:       [OUT] Float64
-  - c:       [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    f = cfn!(n, m, x, c, cutest_lib)
+    f, c = cfn(n, m, x)
 
   - n:       [IN] Int
   - m:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - f:       [OUT] Float64
   - c:       [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    f = cfn!(n, m, x, c)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - f:       [OUT] Float64
+  - c:       [OUT] Array{Float64, 1}
 
     f, c = cfn(nlp, x)
 
@@ -2901,7 +2807,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cofg(io_err, n, x, f, g, grad, cutest_lib)
+    cofg(io_err, n, x, f, g, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -2909,25 +2815,23 @@ Usage:
   - f:       [OUT] Array{Cdouble, 1}
   - g:       [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f, g = cofg(n, x, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - f:       [OUT] Float64
-  - g:       [OUT] Array{Float64, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    f = cofg!(n, x, g, grad, cutest_lib)
+    f, g = cofg(n, x, grad)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - f:       [OUT] Float64
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    f = cofg!(n, x, g, grad)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - f:       [OUT] Float64
+  - g:       [OUT] Array{Float64, 1}
+  - grad:    [IN] Bool
 
     f, g = cofg(nlp, x, grad)
 
@@ -2965,7 +2869,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cofg(io_err, n, x, f, g, grad, cutest_lib)
+    cofg(io_err, n, x, f, g, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -2973,25 +2877,23 @@ Usage:
   - f:       [OUT] Array{Cdouble, 1}
   - g:       [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f, g = cofg(n, x, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - f:       [OUT] Float64
-  - g:       [OUT] Array{Float64, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    f = cofg!(n, x, g, grad, cutest_lib)
+    f, g = cofg(n, x, grad)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - f:       [OUT] Float64
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    f = cofg!(n, x, g, grad)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - f:       [OUT] Float64
+  - g:       [OUT] Array{Float64, 1}
+  - grad:    [IN] Bool
 
     f, g = cofg(nlp, x, grad)
 
@@ -3029,7 +2931,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cofsg(io_err, n, x, f, nnzg, lg, g_val, g_var, grad, cutest_lib)
+    cofsg(io_err, n, x, f, nnzg, lg, g_val, g_var, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3040,21 +2942,9 @@ Usage:
   - g_val:   [OUT] Array{Cdouble, 1}
   - g_var:   [OUT] Array{Cint, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f, nnzg, g_val, g_var = cofsg(n, x, lg, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - f:       [OUT] Float64
-  - nnzg:    [OUT] Int
-  - lg:      [IN] Int
-  - g_val:   [OUT] Array{Float64, 1}
-  - g_var:   [OUT] Array{Int, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    f, nnzg = cofsg!(n, x, lg, g_val, g_var, grad, cutest_lib)
+    f, nnzg, g_val, g_var = cofsg(n, x, lg, grad)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
@@ -3064,7 +2954,17 @@ Usage:
   - g_val:   [OUT] Array{Float64, 1}
   - g_var:   [OUT] Array{Int, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    f, nnzg = cofsg!(n, x, lg, g_val, g_var, grad)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - f:       [OUT] Float64
+  - nnzg:    [OUT] Int
+  - lg:      [IN] Int
+  - g_val:   [OUT] Array{Float64, 1}
+  - g_var:   [OUT] Array{Int, 1}
+  - grad:    [IN] Bool
 
     f, nnzg, g_val, g_var = cofsg(nlp, x, lg, grad)
 
@@ -3108,7 +3008,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cofsg(io_err, n, x, f, nnzg, lg, g_val, g_var, grad, cutest_lib)
+    cofsg(io_err, n, x, f, nnzg, lg, g_val, g_var, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3119,21 +3019,9 @@ Usage:
   - g_val:   [OUT] Array{Cdouble, 1}
   - g_var:   [OUT] Array{Cint, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f, nnzg, g_val, g_var = cofsg(n, x, lg, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - f:       [OUT] Float64
-  - nnzg:    [OUT] Int
-  - lg:      [IN] Int
-  - g_val:   [OUT] Array{Float64, 1}
-  - g_var:   [OUT] Array{Int, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    f, nnzg = cofsg!(n, x, lg, g_val, g_var, grad, cutest_lib)
+    f, nnzg, g_val, g_var = cofsg(n, x, lg, grad)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
@@ -3143,7 +3031,17 @@ Usage:
   - g_val:   [OUT] Array{Float64, 1}
   - g_var:   [OUT] Array{Int, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    f, nnzg = cofsg!(n, x, lg, g_val, g_var, grad)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - f:       [OUT] Float64
+  - nnzg:    [OUT] Int
+  - lg:      [IN] Int
+  - g_val:   [OUT] Array{Float64, 1}
+  - g_var:   [OUT] Array{Int, 1}
+  - grad:    [IN] Bool
 
     f, nnzg, g_val, g_var = cofsg(nlp, x, lg, grad)
 
@@ -3187,7 +3085,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ccfg(io_err, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad, cutest_lib)
+    ccfg(io_err, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3199,22 +3097,9 @@ Usage:
   - lcjac2:  [IN] Array{Cint, 1}
   - cjac:    [OUT] Array{Cdouble, 2}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    c, cjac = ccfg(n, m, x, jtrans, lcjac1, lcjac2, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - c:       [OUT] Array{Float64, 1}
-  - jtrans:  [IN] Bool
-  - lcjac1:  [IN] Int
-  - lcjac2:  [IN] Int
-  - cjac:    [OUT] Array{Float64, 2}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ccfg!(n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad, cutest_lib)
+    c, cjac = ccfg(n, m, x, jtrans, lcjac1, lcjac2, grad)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -3225,7 +3110,18 @@ Usage:
   - lcjac2:  [IN] Int
   - cjac:    [OUT] Array{Float64, 2}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ccfg!(n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - c:       [OUT] Array{Float64, 1}
+  - jtrans:  [IN] Bool
+  - lcjac1:  [IN] Int
+  - lcjac2:  [IN] Int
+  - cjac:    [OUT] Array{Float64, 2}
+  - grad:    [IN] Bool
 
     c, cjac = ccfg(nlp, x, jtrans, lcjac1, lcjac2, grad)
 
@@ -3269,7 +3165,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ccfg(io_err, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad, cutest_lib)
+    ccfg(io_err, n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3281,22 +3177,9 @@ Usage:
   - lcjac2:  [IN] Array{Cint, 1}
   - cjac:    [OUT] Array{Cdouble, 2}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    c, cjac = ccfg(n, m, x, jtrans, lcjac1, lcjac2, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - c:       [OUT] Array{Float64, 1}
-  - jtrans:  [IN] Bool
-  - lcjac1:  [IN] Int
-  - lcjac2:  [IN] Int
-  - cjac:    [OUT] Array{Float64, 2}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ccfg!(n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad, cutest_lib)
+    c, cjac = ccfg(n, m, x, jtrans, lcjac1, lcjac2, grad)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -3307,7 +3190,18 @@ Usage:
   - lcjac2:  [IN] Int
   - cjac:    [OUT] Array{Float64, 2}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ccfg!(n, m, x, c, jtrans, lcjac1, lcjac2, cjac, grad)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - c:       [OUT] Array{Float64, 1}
+  - jtrans:  [IN] Bool
+  - lcjac1:  [IN] Int
+  - lcjac2:  [IN] Int
+  - cjac:    [OUT] Array{Float64, 2}
+  - grad:    [IN] Bool
 
     c, cjac = ccfg(nlp, x, jtrans, lcjac1, lcjac2, grad)
 
@@ -3351,7 +3245,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    clfg(io_err, n, m, x, y, f, g, grad, cutest_lib)
+    clfg(io_err, n, m, x, y, f, g, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3361,20 +3255,9 @@ Usage:
   - f:       [OUT] Array{Cdouble, 1}
   - g:       [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f, g = clfg(n, m, x, y, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - f:       [OUT] Float64
-  - g:       [OUT] Array{Float64, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    f = clfg!(n, m, x, y, g, grad, cutest_lib)
+    f, g = clfg(n, m, x, y, grad)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -3383,7 +3266,16 @@ Usage:
   - f:       [OUT] Float64
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    f = clfg!(n, m, x, y, g, grad)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - f:       [OUT] Float64
+  - g:       [OUT] Array{Float64, 1}
+  - grad:    [IN] Bool
 
     f, g = clfg(nlp, x, y, grad)
 
@@ -3423,7 +3315,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    clfg(io_err, n, m, x, y, f, g, grad, cutest_lib)
+    clfg(io_err, n, m, x, y, f, g, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3433,20 +3325,9 @@ Usage:
   - f:       [OUT] Array{Cdouble, 1}
   - g:       [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    f, g = clfg(n, m, x, y, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - f:       [OUT] Float64
-  - g:       [OUT] Array{Float64, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    f = clfg!(n, m, x, y, g, grad, cutest_lib)
+    f, g = clfg(n, m, x, y, grad)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -3455,7 +3336,16 @@ Usage:
   - f:       [OUT] Float64
   - g:       [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    f = clfg!(n, m, x, y, g, grad)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - f:       [OUT] Float64
+  - g:       [OUT] Array{Float64, 1}
+  - grad:    [IN] Bool
 
     f, g = clfg(nlp, x, y, grad)
 
@@ -3496,7 +3386,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cgr(io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, cutest_lib)
+    cgr(io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3509,23 +3399,9 @@ Usage:
   - lj1:     [IN] Array{Cint, 1}
   - lj2:     [IN] Array{Cint, 1}
   - j_val:   [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g, j_val = cgr(n, m, x, y, grlagf, jtrans, lj1, lj2, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - grlagf:  [IN] Bool
-  - g:       [OUT] Array{Float64, 1}
-  - jtrans:  [IN] Bool
-  - lj1:     [IN] Int
-  - lj2:     [IN] Int
-  - j_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cgr!(n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, cutest_lib)
+    g, j_val = cgr(n, m, x, y, grlagf, jtrans, lj1, lj2)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -3537,7 +3413,19 @@ Usage:
   - lj1:     [IN] Int
   - lj2:     [IN] Int
   - j_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cgr!(n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - grlagf:  [IN] Bool
+  - g:       [OUT] Array{Float64, 1}
+  - jtrans:  [IN] Bool
+  - lj1:     [IN] Int
+  - lj2:     [IN] Int
+  - j_val:   [OUT] Array{Float64, 2}
 
     g, j_val = cgr(nlp, x, y, grlagf, jtrans, lj1, lj2)
 
@@ -3584,7 +3472,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cgr(io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, cutest_lib)
+    cgr(io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3597,23 +3485,9 @@ Usage:
   - lj1:     [IN] Array{Cint, 1}
   - lj2:     [IN] Array{Cint, 1}
   - j_val:   [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g, j_val = cgr(n, m, x, y, grlagf, jtrans, lj1, lj2, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - grlagf:  [IN] Bool
-  - g:       [OUT] Array{Float64, 1}
-  - jtrans:  [IN] Bool
-  - lj1:     [IN] Int
-  - lj2:     [IN] Int
-  - j_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cgr!(n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, cutest_lib)
+    g, j_val = cgr(n, m, x, y, grlagf, jtrans, lj1, lj2)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -3625,7 +3499,19 @@ Usage:
   - lj1:     [IN] Int
   - lj2:     [IN] Int
   - j_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cgr!(n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - grlagf:  [IN] Bool
+  - g:       [OUT] Array{Float64, 1}
+  - jtrans:  [IN] Bool
+  - lj1:     [IN] Int
+  - lj2:     [IN] Int
+  - j_val:   [OUT] Array{Float64, 2}
 
     g, j_val = cgr(nlp, x, y, grlagf, jtrans, lj1, lj2)
 
@@ -3674,7 +3560,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    csgr(io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, cutest_lib)
+    csgr(io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3687,23 +3573,9 @@ Usage:
   - j_val:   [OUT] Array{Cdouble, 1}
   - j_var:   [OUT] Array{Cint, 1}
   - j_fun:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzj, j_val, j_var, j_fun = csgr(n, m, x, y, grlagf, lj, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - grlagf:  [IN] Bool
-  - nnzj:    [OUT] Int
-  - lj:      [IN] Int
-  - j_val:   [OUT] Array{Float64, 1}
-  - j_var:   [OUT] Array{Int, 1}
-  - j_fun:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzj = csgr!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun, cutest_lib)
+    nnzj, j_val, j_var, j_fun = csgr(n, m, x, y, grlagf, lj)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -3715,7 +3587,19 @@ Usage:
   - j_val:   [OUT] Array{Float64, 1}
   - j_var:   [OUT] Array{Int, 1}
   - j_fun:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzj = csgr!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - grlagf:  [IN] Bool
+  - nnzj:    [OUT] Int
+  - lj:      [IN] Int
+  - j_val:   [OUT] Array{Float64, 1}
+  - j_var:   [OUT] Array{Int, 1}
+  - j_fun:   [OUT] Array{Int, 1}
 
     nnzj, j_val, j_var, j_fun = csgr(nlp, x, y, grlagf)
 
@@ -3762,7 +3646,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    csgr(io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, cutest_lib)
+    csgr(io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3775,23 +3659,9 @@ Usage:
   - j_val:   [OUT] Array{Cdouble, 1}
   - j_var:   [OUT] Array{Cint, 1}
   - j_fun:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzj, j_val, j_var, j_fun = csgr(n, m, x, y, grlagf, lj, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - grlagf:  [IN] Bool
-  - nnzj:    [OUT] Int
-  - lj:      [IN] Int
-  - j_val:   [OUT] Array{Float64, 1}
-  - j_var:   [OUT] Array{Int, 1}
-  - j_fun:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzj = csgr!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun, cutest_lib)
+    nnzj, j_val, j_var, j_fun = csgr(n, m, x, y, grlagf, lj)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -3803,7 +3673,19 @@ Usage:
   - j_val:   [OUT] Array{Float64, 1}
   - j_var:   [OUT] Array{Int, 1}
   - j_fun:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzj = csgr!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - grlagf:  [IN] Bool
+  - nnzj:    [OUT] Int
+  - lj:      [IN] Int
+  - j_val:   [OUT] Array{Float64, 1}
+  - j_var:   [OUT] Array{Int, 1}
+  - j_fun:   [OUT] Array{Int, 1}
 
     nnzj, j_val, j_var, j_fun = csgr(nlp, x, y, grlagf)
 
@@ -3848,7 +3730,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ccfsg(io_err, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad, cutest_lib)
+    ccfsg(io_err, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3861,23 +3743,9 @@ Usage:
   - j_var:   [OUT] Array{Cint, 1}
   - j_fun:   [OUT] Array{Cint, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    c, nnzj, j_val, j_var, j_fun = ccfsg(n, m, x, lj, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - c:       [OUT] Array{Float64, 1}
-  - nnzj:    [OUT] Int
-  - lj:      [IN] Int
-  - j_val:   [OUT] Array{Float64, 1}
-  - j_var:   [OUT] Array{Int, 1}
-  - j_fun:   [OUT] Array{Int, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzj = ccfsg!(n, m, x, c, lj, j_val, j_var, j_fun, grad, cutest_lib)
+    c, nnzj, j_val, j_var, j_fun = ccfsg(n, m, x, lj, grad)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -3889,7 +3757,19 @@ Usage:
   - j_var:   [OUT] Array{Int, 1}
   - j_fun:   [OUT] Array{Int, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzj = ccfsg!(n, m, x, c, lj, j_val, j_var, j_fun, grad)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - c:       [OUT] Array{Float64, 1}
+  - nnzj:    [OUT] Int
+  - lj:      [IN] Int
+  - j_val:   [OUT] Array{Float64, 1}
+  - j_var:   [OUT] Array{Int, 1}
+  - j_fun:   [OUT] Array{Int, 1}
+  - grad:    [IN] Bool
 
     c, nnzj, j_val, j_var, j_fun = ccfsg(nlp, x, grad)
 
@@ -3934,7 +3814,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ccfsg(io_err, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad, cutest_lib)
+    ccfsg(io_err, n, m, x, c, nnzj, lj, j_val, j_var, j_fun, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -3947,23 +3827,9 @@ Usage:
   - j_var:   [OUT] Array{Cint, 1}
   - j_fun:   [OUT] Array{Cint, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    c, nnzj, j_val, j_var, j_fun = ccfsg(n, m, x, lj, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - c:       [OUT] Array{Float64, 1}
-  - nnzj:    [OUT] Int
-  - lj:      [IN] Int
-  - j_val:   [OUT] Array{Float64, 1}
-  - j_var:   [OUT] Array{Int, 1}
-  - j_fun:   [OUT] Array{Int, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzj = ccfsg!(n, m, x, c, lj, j_val, j_var, j_fun, grad, cutest_lib)
+    c, nnzj, j_val, j_var, j_fun = ccfsg(n, m, x, lj, grad)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -3975,7 +3841,19 @@ Usage:
   - j_var:   [OUT] Array{Int, 1}
   - j_fun:   [OUT] Array{Int, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzj = ccfsg!(n, m, x, c, lj, j_val, j_var, j_fun, grad)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - c:       [OUT] Array{Float64, 1}
+  - nnzj:    [OUT] Int
+  - lj:      [IN] Int
+  - j_val:   [OUT] Array{Float64, 1}
+  - j_var:   [OUT] Array{Int, 1}
+  - j_fun:   [OUT] Array{Int, 1}
+  - grad:    [IN] Bool
 
     c, nnzj, j_val, j_var, j_fun = ccfsg(nlp, x, grad)
 
@@ -4020,7 +3898,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ccifg(io_err, n, icon, x, ci, gci, grad, cutest_lib)
+    ccifg(io_err, n, icon, x, ci, gci, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4029,19 +3907,9 @@ Usage:
   - ci:      [OUT] Array{Cdouble, 1}
   - gci:     [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    ci, gci = ccifg(n, icon, x, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - icon:    [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - ci:      [OUT] Float64
-  - gci:     [OUT] Array{Float64, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ci = ccifg!(n, icon, x, gci, grad, cutest_lib)
+    ci, gci = ccifg(n, icon, x, grad)
 
   - n:       [IN] Int
   - icon:    [IN] Int
@@ -4049,7 +3917,15 @@ Usage:
   - ci:      [OUT] Float64
   - gci:     [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ci = ccifg!(n, icon, x, gci, grad)
+
+  - n:       [IN] Int
+  - icon:    [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - ci:      [OUT] Float64
+  - gci:     [OUT] Array{Float64, 1}
+  - grad:    [IN] Bool
 
     ci, gci = ccifg(nlp, icon, x, grad)
 
@@ -4090,7 +3966,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ccifg(io_err, n, icon, x, ci, gci, grad, cutest_lib)
+    ccifg(io_err, n, icon, x, ci, gci, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4099,19 +3975,9 @@ Usage:
   - ci:      [OUT] Array{Cdouble, 1}
   - gci:     [OUT] Array{Cdouble, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    ci, gci = ccifg(n, icon, x, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - icon:    [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - ci:      [OUT] Float64
-  - gci:     [OUT] Array{Float64, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ci = ccifg!(n, icon, x, gci, grad, cutest_lib)
+    ci, gci = ccifg(n, icon, x, grad)
 
   - n:       [IN] Int
   - icon:    [IN] Int
@@ -4119,7 +3985,15 @@ Usage:
   - ci:      [OUT] Float64
   - gci:     [OUT] Array{Float64, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ci = ccifg!(n, icon, x, gci, grad)
+
+  - n:       [IN] Int
+  - icon:    [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - ci:      [OUT] Float64
+  - gci:     [OUT] Array{Float64, 1}
+  - grad:    [IN] Bool
 
     ci, gci = ccifg(nlp, icon, x, grad)
 
@@ -4161,7 +4035,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ccifsg(io_err, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad, cutest_lib)
+    ccifsg(io_err, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4173,22 +4047,9 @@ Usage:
   - gci_val: [OUT] Array{Cdouble, 1}
   - gci_var: [OUT] Array{Cint, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    ci, nnzgci, gci_val, gci_var = ccifsg(n, icon, x, lgci, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - icon:    [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - ci:      [OUT] Float64
-  - nnzgci:  [OUT] Int
-  - lgci:    [IN] Int
-  - gci_val: [OUT] Array{Float64, 1}
-  - gci_var: [OUT] Array{Int, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ci, nnzgci = ccifsg!(n, icon, x, lgci, gci_val, gci_var, grad, cutest_lib)
+    ci, nnzgci, gci_val, gci_var = ccifsg(n, icon, x, lgci, grad)
 
   - n:       [IN] Int
   - icon:    [IN] Int
@@ -4199,7 +4060,18 @@ Usage:
   - gci_val: [OUT] Array{Float64, 1}
   - gci_var: [OUT] Array{Int, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ci, nnzgci = ccifsg!(n, icon, x, lgci, gci_val, gci_var, grad)
+
+  - n:       [IN] Int
+  - icon:    [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - ci:      [OUT] Float64
+  - nnzgci:  [OUT] Int
+  - lgci:    [IN] Int
+  - gci_val: [OUT] Array{Float64, 1}
+  - gci_var: [OUT] Array{Int, 1}
+  - grad:    [IN] Bool
 
     ci, nnzgci, gci_val, gci_var = ccifsg(nlp, icon, x, lgci, grad)
 
@@ -4247,7 +4119,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    ccifsg(io_err, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad, cutest_lib)
+    ccifsg(io_err, n, icon, x, ci, nnzgci, lgci, gci_val, gci_var, grad)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4259,22 +4131,9 @@ Usage:
   - gci_val: [OUT] Array{Cdouble, 1}
   - gci_var: [OUT] Array{Cint, 1}
   - grad:    [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    ci, nnzgci, gci_val, gci_var = ccifsg(n, icon, x, lgci, grad, cutest_lib)
 
-  - n:       [IN] Int
-  - icon:    [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - ci:      [OUT] Float64
-  - nnzgci:  [OUT] Int
-  - lgci:    [IN] Int
-  - gci_val: [OUT] Array{Float64, 1}
-  - gci_var: [OUT] Array{Int, 1}
-  - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ci, nnzgci = ccifsg!(n, icon, x, lgci, gci_val, gci_var, grad, cutest_lib)
+    ci, nnzgci, gci_val, gci_var = ccifsg(n, icon, x, lgci, grad)
 
   - n:       [IN] Int
   - icon:    [IN] Int
@@ -4285,7 +4144,18 @@ Usage:
   - gci_val: [OUT] Array{Float64, 1}
   - gci_var: [OUT] Array{Int, 1}
   - grad:    [IN] Bool
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ci, nnzgci = ccifsg!(n, icon, x, lgci, gci_val, gci_var, grad)
+
+  - n:       [IN] Int
+  - icon:    [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - ci:      [OUT] Float64
+  - nnzgci:  [OUT] Int
+  - lgci:    [IN] Int
+  - gci_val: [OUT] Array{Float64, 1}
+  - gci_var: [OUT] Array{Int, 1}
+  - grad:    [IN] Bool
 
     ci, nnzgci, gci_val, gci_var = ccifsg(nlp, icon, x, lgci, grad)
 
@@ -4334,7 +4204,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cgrdh(io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val, cutest_lib)
+    cgrdh(io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4349,25 +4219,9 @@ Usage:
   - j_val:   [OUT] Array{Cdouble, 2}
   - lh1:     [IN] Array{Cint, 1}
   - h_val:   [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g, j_val, h_val = cgrdh(n, m, x, y, grlagf, jtrans, lj1, lj2, lh1, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - grlagf:  [IN] Bool
-  - g:       [OUT] Array{Float64, 1}
-  - jtrans:  [IN] Bool
-  - lj1:     [IN] Int
-  - lj2:     [IN] Int
-  - j_val:   [OUT] Array{Float64, 2}
-  - lh1:     [IN] Int
-  - h_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cgrdh!(n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val, cutest_lib)
+    g, j_val, h_val = cgrdh(n, m, x, y, grlagf, jtrans, lj1, lj2, lh1)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -4381,7 +4235,21 @@ Usage:
   - j_val:   [OUT] Array{Float64, 2}
   - lh1:     [IN] Int
   - h_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cgrdh!(n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - grlagf:  [IN] Bool
+  - g:       [OUT] Array{Float64, 1}
+  - jtrans:  [IN] Bool
+  - lj1:     [IN] Int
+  - lj2:     [IN] Int
+  - j_val:   [OUT] Array{Float64, 2}
+  - lh1:     [IN] Int
+  - h_val:   [OUT] Array{Float64, 2}
 
     g, j_val, h_val = cgrdh(nlp, x, y, grlagf, jtrans, lj1, lj2, lh1)
 
@@ -4434,7 +4302,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cgrdh(io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val, cutest_lib)
+    cgrdh(io_err, n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4449,25 +4317,9 @@ Usage:
   - j_val:   [OUT] Array{Cdouble, 2}
   - lh1:     [IN] Array{Cint, 1}
   - h_val:   [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    g, j_val, h_val = cgrdh(n, m, x, y, grlagf, jtrans, lj1, lj2, lh1, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - grlagf:  [IN] Bool
-  - g:       [OUT] Array{Float64, 1}
-  - jtrans:  [IN] Bool
-  - lj1:     [IN] Int
-  - lj2:     [IN] Int
-  - j_val:   [OUT] Array{Float64, 2}
-  - lh1:     [IN] Int
-  - h_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cgrdh!(n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val, cutest_lib)
+    g, j_val, h_val = cgrdh(n, m, x, y, grlagf, jtrans, lj1, lj2, lh1)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -4481,7 +4333,21 @@ Usage:
   - j_val:   [OUT] Array{Float64, 2}
   - lh1:     [IN] Int
   - h_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cgrdh!(n, m, x, y, grlagf, g, jtrans, lj1, lj2, j_val, lh1, h_val)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - grlagf:  [IN] Bool
+  - g:       [OUT] Array{Float64, 1}
+  - jtrans:  [IN] Bool
+  - lj1:     [IN] Int
+  - lj2:     [IN] Int
+  - j_val:   [OUT] Array{Float64, 2}
+  - lh1:     [IN] Int
+  - h_val:   [OUT] Array{Float64, 2}
 
     g, j_val, h_val = cgrdh(nlp, x, y, grlagf, jtrans, lj1, lj2, lh1)
 
@@ -4532,7 +4398,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cdh(io_err, n, m, x, y, lh1, h_val, cutest_lib)
+    cdh(io_err, n, m, x, y, lh1, h_val)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4541,19 +4407,9 @@ Usage:
   - y:       [IN] Array{Cdouble, 1}
   - lh1:     [IN] Array{Cint, 1}
   - h_val:   [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    h_val = cdh(n, m, x, y, lh1, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - lh1:     [IN] Int
-  - h_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cdh!(n, m, x, y, lh1, h_val, cutest_lib)
+    h_val = cdh(n, m, x, y, lh1)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -4561,7 +4417,15 @@ Usage:
   - y:       [IN] Array{Float64, 1}
   - lh1:     [IN] Int
   - h_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cdh!(n, m, x, y, lh1, h_val)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - lh1:     [IN] Int
+  - h_val:   [OUT] Array{Float64, 2}
 
     h_val = cdh(nlp, x, y, lh1)
 
@@ -4600,7 +4464,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cdh(io_err, n, m, x, y, lh1, h_val, cutest_lib)
+    cdh(io_err, n, m, x, y, lh1, h_val)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4609,19 +4473,9 @@ Usage:
   - y:       [IN] Array{Cdouble, 1}
   - lh1:     [IN] Array{Cint, 1}
   - h_val:   [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    h_val = cdh(n, m, x, y, lh1, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - lh1:     [IN] Int
-  - h_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cdh!(n, m, x, y, lh1, h_val, cutest_lib)
+    h_val = cdh(n, m, x, y, lh1)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -4629,7 +4483,15 @@ Usage:
   - y:       [IN] Array{Float64, 1}
   - lh1:     [IN] Int
   - h_val:   [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cdh!(n, m, x, y, lh1, h_val)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - lh1:     [IN] Int
+  - h_val:   [OUT] Array{Float64, 2}
 
     h_val = cdh(nlp, x, y, lh1)
 
@@ -4668,7 +4530,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    csh(io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col, cutest_lib)
+    csh(io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4680,22 +4542,9 @@ Usage:
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzh, h_val, h_row, h_col = csh(n, m, x, y, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzh = csh!(n, m, x, y, lh, h_val, h_row, h_col, cutest_lib)
+    nnzh, h_val, h_row, h_col = csh(n, m, x, y, lh)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -4706,7 +4555,18 @@ Usage:
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzh = csh!(n, m, x, y, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     nnzh, h_val, h_row, h_col = csh(nlp, x, y)
 
@@ -4749,7 +4609,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    csh(io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col, cutest_lib)
+    csh(io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4761,22 +4621,9 @@ Usage:
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzh, h_val, h_row, h_col = csh(n, m, x, y, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzh = csh!(n, m, x, y, lh, h_val, h_row, h_col, cutest_lib)
+    nnzh, h_val, h_row, h_col = csh(n, m, x, y, lh)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -4787,7 +4634,18 @@ Usage:
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzh = csh!(n, m, x, y, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     nnzh, h_val, h_row, h_col = csh(nlp, x, y)
 
@@ -4830,7 +4688,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cshc(io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col, cutest_lib)
+    cshc(io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4842,22 +4700,9 @@ Usage:
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzh, h_val, h_row, h_col = cshc(n, m, x, y, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzh = cshc!(n, m, x, y, lh, h_val, h_row, h_col, cutest_lib)
+    nnzh, h_val, h_row, h_col = cshc(n, m, x, y, lh)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -4868,7 +4713,18 @@ Usage:
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzh = cshc!(n, m, x, y, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     nnzh, h_val, h_row, h_col = cshc(nlp, x, y)
 
@@ -4911,7 +4767,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cshc(io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col, cutest_lib)
+    cshc(io_err, n, m, x, y, nnzh, lh, h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -4923,22 +4779,9 @@ Usage:
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzh, h_val, h_row, h_col = cshc(n, m, x, y, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzh = cshc!(n, m, x, y, lh, h_val, h_row, h_col, cutest_lib)
+    nnzh, h_val, h_row, h_col = cshc(n, m, x, y, lh)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -4949,7 +4792,18 @@ Usage:
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzh = cshc!(n, m, x, y, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     nnzh, h_val, h_row, h_col = cshc(nlp, x, y)
 
@@ -4995,7 +4849,7 @@ errors. For more information, run the shell command
 Usage:
 
     ceh(io_err, n, m, x, y, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row,
-he_row, lhe_val, he_val, byrows, cutest_lib)
+he_row, lhe_val, he_val, byrows)
 
   - io_err:     [OUT] Array{Cint, 1}
   - n:          [IN] Array{Cint, 1}
@@ -5011,26 +4865,9 @@ he_row, lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Array{Cint, 1}
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    ne, he_row_ptr, he_val_ptr, he_row, he_val = ceh(n, m, x, y, lhe_ptr, lhe_row, lhe_val, byrows, cutest_lib)
 
-  - n:          [IN] Int
-  - m:          [IN] Int
-  - x:          [IN] Array{Float64, 1}
-  - y:          [IN] Array{Float64, 1}
-  - ne:         [OUT] Int
-  - lhe_ptr:    [IN] Int
-  - he_row_ptr: [OUT] Array{Int, 1}
-  - he_val_ptr: [OUT] Array{Int, 1}
-  - lhe_row:    [IN] Int
-  - he_row:     [OUT] Array{Int, 1}
-  - lhe_val:    [IN] Int
-  - he_val:     [OUT] Array{Float64, 1}
-  - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ne = ceh!(n, m, x, y, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows, cutest_lib)
+    ne, he_row_ptr, he_val_ptr, he_row, he_val = ceh(n, m, x, y, lhe_ptr, lhe_row, lhe_val, byrows)
 
   - n:          [IN] Int
   - m:          [IN] Int
@@ -5045,7 +4882,22 @@ he_row, lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Int
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ne = ceh!(n, m, x, y, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+
+  - n:          [IN] Int
+  - m:          [IN] Int
+  - x:          [IN] Array{Float64, 1}
+  - y:          [IN] Array{Float64, 1}
+  - ne:         [OUT] Int
+  - lhe_ptr:    [IN] Int
+  - he_row_ptr: [OUT] Array{Int, 1}
+  - he_val_ptr: [OUT] Array{Int, 1}
+  - lhe_row:    [IN] Int
+  - he_row:     [OUT] Array{Int, 1}
+  - lhe_val:    [IN] Int
+  - he_val:     [OUT] Array{Float64, 1}
+  - byrows:     [IN] Bool
 
     ne, he_row_ptr, he_val_ptr, he_row, he_val = ceh(nlp, x, y, lhe_ptr, lhe_row, lhe_val, byrows)
 
@@ -5101,7 +4953,7 @@ errors. For more information, run the shell command
 Usage:
 
     ceh(io_err, n, m, x, y, ne, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row,
-he_row, lhe_val, he_val, byrows, cutest_lib)
+he_row, lhe_val, he_val, byrows)
 
   - io_err:     [OUT] Array{Cint, 1}
   - n:          [IN] Array{Cint, 1}
@@ -5117,26 +4969,9 @@ he_row, lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Array{Cint, 1}
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    ne, he_row_ptr, he_val_ptr, he_row, he_val = ceh(n, m, x, y, lhe_ptr, lhe_row, lhe_val, byrows, cutest_lib)
 
-  - n:          [IN] Int
-  - m:          [IN] Int
-  - x:          [IN] Array{Float64, 1}
-  - y:          [IN] Array{Float64, 1}
-  - ne:         [OUT] Int
-  - lhe_ptr:    [IN] Int
-  - he_row_ptr: [OUT] Array{Int, 1}
-  - he_val_ptr: [OUT] Array{Int, 1}
-  - lhe_row:    [IN] Int
-  - he_row:     [OUT] Array{Int, 1}
-  - lhe_val:    [IN] Int
-  - he_val:     [OUT] Array{Float64, 1}
-  - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    ne = ceh!(n, m, x, y, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows, cutest_lib)
+    ne, he_row_ptr, he_val_ptr, he_row, he_val = ceh(n, m, x, y, lhe_ptr, lhe_row, lhe_val, byrows)
 
   - n:          [IN] Int
   - m:          [IN] Int
@@ -5151,7 +4986,22 @@ he_row, lhe_val, he_val, byrows, cutest_lib)
   - lhe_val:    [IN] Int
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    ne = ceh!(n, m, x, y, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+
+  - n:          [IN] Int
+  - m:          [IN] Int
+  - x:          [IN] Array{Float64, 1}
+  - y:          [IN] Array{Float64, 1}
+  - ne:         [OUT] Int
+  - lhe_ptr:    [IN] Int
+  - he_row_ptr: [OUT] Array{Int, 1}
+  - he_val_ptr: [OUT] Array{Int, 1}
+  - lhe_row:    [IN] Int
+  - he_row:     [OUT] Array{Int, 1}
+  - lhe_val:    [IN] Int
+  - he_val:     [OUT] Array{Float64, 1}
+  - byrows:     [IN] Bool
 
     ne, he_row_ptr, he_val_ptr, he_row, he_val = ceh(nlp, x, y, lhe_ptr, lhe_row, lhe_val, byrows)
 
@@ -5204,7 +5054,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cidh(io_err, n, x, iprob, lh1, h, cutest_lib)
+    cidh(io_err, n, x, iprob, lh1, h)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -5212,25 +5062,23 @@ Usage:
   - iprob:   [IN] Array{Cint, 1}
   - lh1:     [IN] Array{Cint, 1}
   - h:       [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    h = cidh(n, x, iprob, lh1, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - iprob:   [IN] Int
-  - lh1:     [IN] Int
-  - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cidh!(n, x, iprob, lh1, h, cutest_lib)
+    h = cidh(n, x, iprob, lh1)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - iprob:   [IN] Int
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cidh!(n, x, iprob, lh1, h)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - iprob:   [IN] Int
+  - lh1:     [IN] Int
+  - h:       [OUT] Array{Float64, 2}
 
     h = cidh(nlp, x, iprob, lh1)
 
@@ -5269,7 +5117,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cidh(io_err, n, x, iprob, lh1, h, cutest_lib)
+    cidh(io_err, n, x, iprob, lh1, h)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -5277,25 +5125,23 @@ Usage:
   - iprob:   [IN] Array{Cint, 1}
   - lh1:     [IN] Array{Cint, 1}
   - h:       [OUT] Array{Cdouble, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    h = cidh(n, x, iprob, lh1, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - iprob:   [IN] Int
-  - lh1:     [IN] Int
-  - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cidh!(n, x, iprob, lh1, h, cutest_lib)
+    h = cidh(n, x, iprob, lh1)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
   - iprob:   [IN] Int
   - lh1:     [IN] Int
   - h:       [OUT] Array{Float64, 2}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cidh!(n, x, iprob, lh1, h)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - iprob:   [IN] Int
+  - lh1:     [IN] Int
+  - h:       [OUT] Array{Float64, 2}
 
     h = cidh(nlp, x, iprob, lh1)
 
@@ -5334,7 +5180,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cish(io_err, n, x, iprob, nnzh, lh, h_val, h_row, h_col, cutest_lib)
+    cish(io_err, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -5345,21 +5191,9 @@ Usage:
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzh, h_val, h_row, h_col = cish(n, x, iprob, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - iprob:   [IN] Int
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzh = cish!(n, x, iprob, lh, h_val, h_row, h_col, cutest_lib)
+    nnzh, h_val, h_row, h_col = cish(n, x, iprob, lh)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
@@ -5369,7 +5203,17 @@ Usage:
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzh = cish!(n, x, iprob, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - iprob:   [IN] Int
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     nnzh, h_val, h_row, h_col = cish(nlp, x, iprob)
 
@@ -5412,7 +5256,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cish(io_err, n, x, iprob, nnzh, lh, h_val, h_row, h_col, cutest_lib)
+    cish(io_err, n, x, iprob, nnzh, lh, h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -5423,21 +5267,9 @@ Usage:
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzh, h_val, h_row, h_col = cish(n, x, iprob, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - iprob:   [IN] Int
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzh = cish!(n, x, iprob, lh, h_val, h_row, h_col, cutest_lib)
+    nnzh, h_val, h_row, h_col = cish(n, x, iprob, lh)
 
   - n:       [IN] Int
   - x:       [IN] Array{Float64, 1}
@@ -5447,7 +5279,17 @@ Usage:
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzh = cish!(n, x, iprob, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - iprob:   [IN] Int
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     nnzh, h_val, h_row, h_col = cish(nlp, x, iprob)
 
@@ -5493,7 +5335,7 @@ errors. For more information, run the shell command
 Usage:
 
     csgrsh(io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, nnzh, lh,
-h_val, h_row, h_col, cutest_lib)
+h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -5511,28 +5353,9 @@ h_val, h_row, h_col, cutest_lib)
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzj, j_val, j_var, j_fun, nnzh, h_val, h_row, h_col = csgrsh(n, m, x, y, grlagf, lj, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - grlagf:  [IN] Bool
-  - nnzj:    [OUT] Int
-  - lj:      [IN] Int
-  - j_val:   [OUT] Array{Float64, 1}
-  - j_var:   [OUT] Array{Int, 1}
-  - j_fun:   [OUT] Array{Int, 1}
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzj, nnzh = csgrsh!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun, lh, h_val, h_row, h_col, cutest_lib)
+    nnzj, j_val, j_var, j_fun, nnzh, h_val, h_row, h_col = csgrsh(n, m, x, y, grlagf, lj, lh)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -5549,7 +5372,24 @@ h_val, h_row, h_col, cutest_lib)
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzj, nnzh = csgrsh!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - grlagf:  [IN] Bool
+  - nnzj:    [OUT] Int
+  - lj:      [IN] Int
+  - j_val:   [OUT] Array{Float64, 1}
+  - j_var:   [OUT] Array{Int, 1}
+  - j_fun:   [OUT] Array{Int, 1}
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     nnzj, j_val, j_var, j_fun, nnzh, h_val, h_row, h_col = csgrsh(nlp, x, y, grlagf)
 
@@ -5605,7 +5445,7 @@ errors. For more information, run the shell command
 Usage:
 
     csgrsh(io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, nnzh, lh,
-h_val, h_row, h_col, cutest_lib)
+h_val, h_row, h_col)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -5623,28 +5463,9 @@ h_val, h_row, h_col, cutest_lib)
   - h_val:   [OUT] Array{Cdouble, 1}
   - h_row:   [OUT] Array{Cint, 1}
   - h_col:   [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzj, j_val, j_var, j_fun, nnzh, h_val, h_row, h_col = csgrsh(n, m, x, y, grlagf, lj, lh, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - grlagf:  [IN] Bool
-  - nnzj:    [OUT] Int
-  - lj:      [IN] Int
-  - j_val:   [OUT] Array{Float64, 1}
-  - j_var:   [OUT] Array{Int, 1}
-  - j_fun:   [OUT] Array{Int, 1}
-  - nnzh:    [OUT] Int
-  - lh:      [IN] Int
-  - h_val:   [OUT] Array{Float64, 1}
-  - h_row:   [OUT] Array{Int, 1}
-  - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzj, nnzh = csgrsh!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun, lh, h_val, h_row, h_col, cutest_lib)
+    nnzj, j_val, j_var, j_fun, nnzh, h_val, h_row, h_col = csgrsh(n, m, x, y, grlagf, lj, lh)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -5661,7 +5482,24 @@ h_val, h_row, h_col, cutest_lib)
   - h_val:   [OUT] Array{Float64, 1}
   - h_row:   [OUT] Array{Int, 1}
   - h_col:   [OUT] Array{Int, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzj, nnzh = csgrsh!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun, lh, h_val, h_row, h_col)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - grlagf:  [IN] Bool
+  - nnzj:    [OUT] Int
+  - lj:      [IN] Int
+  - j_val:   [OUT] Array{Float64, 1}
+  - j_var:   [OUT] Array{Int, 1}
+  - j_fun:   [OUT] Array{Int, 1}
+  - nnzh:    [OUT] Int
+  - lh:      [IN] Int
+  - h_val:   [OUT] Array{Float64, 1}
+  - h_row:   [OUT] Array{Int, 1}
+  - h_col:   [OUT] Array{Int, 1}
 
     nnzj, j_val, j_var, j_fun, nnzh, h_val, h_row, h_col = csgrsh(nlp, x, y, grlagf)
 
@@ -5721,7 +5559,7 @@ Usage:
 
     csgreh(io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, ne,
 lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val,
-byrows, cutest_lib)
+byrows)
 
   - io_err:     [OUT] Array{Cint, 1}
   - n:          [IN] Array{Cint, 1}
@@ -5743,32 +5581,9 @@ byrows, cutest_lib)
   - lhe_val:    [IN] Array{Cint, 1}
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzj, j_val, j_var, j_fun, ne, he_row_ptr, he_val_ptr, he_row, he_val = csgreh(n, m, x, y, grlagf, lj, lhe_ptr, lhe_row, lhe_val, byrows, cutest_lib)
 
-  - n:          [IN] Int
-  - m:          [IN] Int
-  - x:          [IN] Array{Float64, 1}
-  - y:          [IN] Array{Float64, 1}
-  - grlagf:     [IN] Bool
-  - nnzj:       [OUT] Int
-  - lj:         [IN] Int
-  - j_val:      [OUT] Array{Float64, 1}
-  - j_var:      [OUT] Array{Int, 1}
-  - j_fun:      [OUT] Array{Int, 1}
-  - ne:         [OUT] Int
-  - lhe_ptr:    [IN] Int
-  - he_row_ptr: [OUT] Array{Int, 1}
-  - he_val_ptr: [OUT] Array{Int, 1}
-  - lhe_row:    [IN] Int
-  - he_row:     [OUT] Array{Int, 1}
-  - lhe_val:    [IN] Int
-  - he_val:     [OUT] Array{Float64, 1}
-  - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzj, ne = csgreh!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows, cutest_lib)
+    nnzj, j_val, j_var, j_fun, ne, he_row_ptr, he_val_ptr, he_row, he_val = csgreh(n, m, x, y, grlagf, lj, lhe_ptr, lhe_row, lhe_val, byrows)
 
   - n:          [IN] Int
   - m:          [IN] Int
@@ -5789,7 +5604,28 @@ byrows, cutest_lib)
   - lhe_val:    [IN] Int
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzj, ne = csgreh!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+
+  - n:          [IN] Int
+  - m:          [IN] Int
+  - x:          [IN] Array{Float64, 1}
+  - y:          [IN] Array{Float64, 1}
+  - grlagf:     [IN] Bool
+  - nnzj:       [OUT] Int
+  - lj:         [IN] Int
+  - j_val:      [OUT] Array{Float64, 1}
+  - j_var:      [OUT] Array{Int, 1}
+  - j_fun:      [OUT] Array{Int, 1}
+  - ne:         [OUT] Int
+  - lhe_ptr:    [IN] Int
+  - he_row_ptr: [OUT] Array{Int, 1}
+  - he_val_ptr: [OUT] Array{Int, 1}
+  - lhe_row:    [IN] Int
+  - he_row:     [OUT] Array{Int, 1}
+  - lhe_val:    [IN] Int
+  - he_val:     [OUT] Array{Float64, 1}
+  - byrows:     [IN] Bool
 
     nnzj, j_val, j_var, j_fun, ne, he_row_ptr, he_val_ptr, he_row, he_val = csgreh(nlp, x, y, grlagf, lhe_ptr, lhe_row, lhe_val, byrows)
 
@@ -5859,7 +5695,7 @@ Usage:
 
     csgreh(io_err, n, m, x, y, grlagf, nnzj, lj, j_val, j_var, j_fun, ne,
 lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val,
-byrows, cutest_lib)
+byrows)
 
   - io_err:     [OUT] Array{Cint, 1}
   - n:          [IN] Array{Cint, 1}
@@ -5881,32 +5717,9 @@ byrows, cutest_lib)
   - lhe_val:    [IN] Array{Cint, 1}
   - he_val:     [OUT] Array{Cdouble, 1}
   - byrows:     [IN] Array{Cint, 1}
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    nnzj, j_val, j_var, j_fun, ne, he_row_ptr, he_val_ptr, he_row, he_val = csgreh(n, m, x, y, grlagf, lj, lhe_ptr, lhe_row, lhe_val, byrows, cutest_lib)
 
-  - n:          [IN] Int
-  - m:          [IN] Int
-  - x:          [IN] Array{Float64, 1}
-  - y:          [IN] Array{Float64, 1}
-  - grlagf:     [IN] Bool
-  - nnzj:       [OUT] Int
-  - lj:         [IN] Int
-  - j_val:      [OUT] Array{Float64, 1}
-  - j_var:      [OUT] Array{Int, 1}
-  - j_fun:      [OUT] Array{Int, 1}
-  - ne:         [OUT] Int
-  - lhe_ptr:    [IN] Int
-  - he_row_ptr: [OUT] Array{Int, 1}
-  - he_val_ptr: [OUT] Array{Int, 1}
-  - lhe_row:    [IN] Int
-  - he_row:     [OUT] Array{Int, 1}
-  - lhe_val:    [IN] Int
-  - he_val:     [OUT] Array{Float64, 1}
-  - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    nnzj, ne = csgreh!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows, cutest_lib)
+    nnzj, j_val, j_var, j_fun, ne, he_row_ptr, he_val_ptr, he_row, he_val = csgreh(n, m, x, y, grlagf, lj, lhe_ptr, lhe_row, lhe_val, byrows)
 
   - n:          [IN] Int
   - m:          [IN] Int
@@ -5927,7 +5740,28 @@ byrows, cutest_lib)
   - lhe_val:    [IN] Int
   - he_val:     [OUT] Array{Float64, 1}
   - byrows:     [IN] Bool
-  - cutest_lib:    [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    nnzj, ne = csgreh!(n, m, x, y, grlagf, lj, j_val, j_var, j_fun, lhe_ptr, he_row_ptr, he_val_ptr, lhe_row, he_row, lhe_val, he_val, byrows)
+
+  - n:          [IN] Int
+  - m:          [IN] Int
+  - x:          [IN] Array{Float64, 1}
+  - y:          [IN] Array{Float64, 1}
+  - grlagf:     [IN] Bool
+  - nnzj:       [OUT] Int
+  - lj:         [IN] Int
+  - j_val:      [OUT] Array{Float64, 1}
+  - j_var:      [OUT] Array{Int, 1}
+  - j_fun:      [OUT] Array{Int, 1}
+  - ne:         [OUT] Int
+  - lhe_ptr:    [IN] Int
+  - he_row_ptr: [OUT] Array{Int, 1}
+  - he_val_ptr: [OUT] Array{Int, 1}
+  - lhe_row:    [IN] Int
+  - he_row:     [OUT] Array{Int, 1}
+  - lhe_val:    [IN] Int
+  - he_val:     [OUT] Array{Float64, 1}
+  - byrows:     [IN] Bool
 
     nnzj, j_val, j_var, j_fun, ne, he_row_ptr, he_val_ptr, he_row, he_val = csgreh(nlp, x, y, grlagf, lhe_ptr, lhe_row, lhe_val, byrows)
 
@@ -5990,7 +5824,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    chprod(io_err, n, m, goth, x, y, vector, result, cutest_lib)
+    chprod(io_err, n, m, goth, x, y, vector, result)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -6000,20 +5834,9 @@ Usage:
   - y:       [IN] Array{Cdouble, 1}
   - vector:  [IN] Array{Cdouble, 1}
   - result:  [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    result = chprod(n, m, goth, x, y, vector, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - goth:    [IN] Bool
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - vector:  [IN] Array{Float64, 1}
-  - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    chprod!(n, m, goth, x, y, vector, result, cutest_lib)
+    result = chprod(n, m, goth, x, y, vector)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -6022,7 +5845,16 @@ Usage:
   - y:       [IN] Array{Float64, 1}
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    chprod!(n, m, goth, x, y, vector, result)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - goth:    [IN] Bool
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - vector:  [IN] Array{Float64, 1}
+  - result:  [OUT] Array{Float64, 1}
 
     result = chprod(nlp, goth, x, y, vector)
 
@@ -6063,7 +5895,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    chprod(io_err, n, m, goth, x, y, vector, result, cutest_lib)
+    chprod(io_err, n, m, goth, x, y, vector, result)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -6073,20 +5905,9 @@ Usage:
   - y:       [IN] Array{Cdouble, 1}
   - vector:  [IN] Array{Cdouble, 1}
   - result:  [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    result = chprod(n, m, goth, x, y, vector, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - goth:    [IN] Bool
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - vector:  [IN] Array{Float64, 1}
-  - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    chprod!(n, m, goth, x, y, vector, result, cutest_lib)
+    result = chprod(n, m, goth, x, y, vector)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -6095,7 +5916,16 @@ Usage:
   - y:       [IN] Array{Float64, 1}
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    chprod!(n, m, goth, x, y, vector, result)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - goth:    [IN] Bool
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - vector:  [IN] Array{Float64, 1}
+  - result:  [OUT] Array{Float64, 1}
 
     result = chprod(nlp, goth, x, y, vector)
 
@@ -6136,7 +5966,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    chcprod(io_err, n, m, goth, x, y, vector, result, cutest_lib)
+    chcprod(io_err, n, m, goth, x, y, vector, result)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -6146,20 +5976,9 @@ Usage:
   - y:       [IN] Array{Cdouble, 1}
   - vector:  [IN] Array{Cdouble, 1}
   - result:  [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    result = chcprod(n, m, goth, x, y, vector, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - goth:    [IN] Bool
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - vector:  [IN] Array{Float64, 1}
-  - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    chcprod!(n, m, goth, x, y, vector, result, cutest_lib)
+    result = chcprod(n, m, goth, x, y, vector)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -6168,7 +5987,16 @@ Usage:
   - y:       [IN] Array{Float64, 1}
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    chcprod!(n, m, goth, x, y, vector, result)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - goth:    [IN] Bool
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - vector:  [IN] Array{Float64, 1}
+  - result:  [OUT] Array{Float64, 1}
 
     result = chcprod(nlp, goth, x, y, vector)
 
@@ -6209,7 +6037,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    chcprod(io_err, n, m, goth, x, y, vector, result, cutest_lib)
+    chcprod(io_err, n, m, goth, x, y, vector, result)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -6219,20 +6047,9 @@ Usage:
   - y:       [IN] Array{Cdouble, 1}
   - vector:  [IN] Array{Cdouble, 1}
   - result:  [OUT] Array{Cdouble, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    result = chcprod(n, m, goth, x, y, vector, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - goth:    [IN] Bool
-  - x:       [IN] Array{Float64, 1}
-  - y:       [IN] Array{Float64, 1}
-  - vector:  [IN] Array{Float64, 1}
-  - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    chcprod!(n, m, goth, x, y, vector, result, cutest_lib)
+    result = chcprod(n, m, goth, x, y, vector)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -6241,7 +6058,16 @@ Usage:
   - y:       [IN] Array{Float64, 1}
   - vector:  [IN] Array{Float64, 1}
   - result:  [OUT] Array{Float64, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    chcprod!(n, m, goth, x, y, vector, result)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - goth:    [IN] Bool
+  - x:       [IN] Array{Float64, 1}
+  - y:       [IN] Array{Float64, 1}
+  - vector:  [IN] Array{Float64, 1}
+  - result:  [OUT] Array{Float64, 1}
 
     result = chcprod(nlp, goth, x, y, vector)
 
@@ -6282,7 +6108,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cjprod(io_err, n, m, gotj, jtrans, x, vector, lvector, result, lresult, cutest_lib)
+    cjprod(io_err, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -6294,22 +6120,9 @@ Usage:
   - lvector: [IN] Array{Cint, 1}
   - result:  [OUT] Array{Cdouble, 1}
   - lresult: [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    result = cjprod(n, m, gotj, jtrans, x, vector, lvector, lresult, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - gotj:    [IN] Bool
-  - jtrans:  [IN] Bool
-  - x:       [IN] Array{Float64, 1}
-  - vector:  [IN] Array{Float64, 1}
-  - lvector: [IN] Int
-  - result:  [OUT] Array{Float64, 1}
-  - lresult: [IN] Int
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cjprod!(n, m, gotj, jtrans, x, vector, lvector, result, lresult, cutest_lib)
+    result = cjprod(n, m, gotj, jtrans, x, vector, lvector, lresult)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -6320,7 +6133,18 @@ Usage:
   - lvector: [IN] Int
   - result:  [OUT] Array{Float64, 1}
   - lresult: [IN] Int
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cjprod!(n, m, gotj, jtrans, x, vector, lvector, result, lresult)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - gotj:    [IN] Bool
+  - jtrans:  [IN] Bool
+  - x:       [IN] Array{Float64, 1}
+  - vector:  [IN] Array{Float64, 1}
+  - lvector: [IN] Int
+  - result:  [OUT] Array{Float64, 1}
+  - lresult: [IN] Int
 
     result = cjprod(nlp, gotj, jtrans, x, vector, lvector, lresult)
 
@@ -6365,7 +6189,7 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cjprod(io_err, n, m, gotj, jtrans, x, vector, lvector, result, lresult, cutest_lib)
+    cjprod(io_err, n, m, gotj, jtrans, x, vector, lvector, result, lresult)
 
   - io_err:  [OUT] Array{Cint, 1}
   - n:       [IN] Array{Cint, 1}
@@ -6377,22 +6201,9 @@ Usage:
   - lvector: [IN] Array{Cint, 1}
   - result:  [OUT] Array{Cdouble, 1}
   - lresult: [IN] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    result = cjprod(n, m, gotj, jtrans, x, vector, lvector, lresult, cutest_lib)
 
-  - n:       [IN] Int
-  - m:       [IN] Int
-  - gotj:    [IN] Bool
-  - jtrans:  [IN] Bool
-  - x:       [IN] Array{Float64, 1}
-  - vector:  [IN] Array{Float64, 1}
-  - lvector: [IN] Int
-  - result:  [OUT] Array{Float64, 1}
-  - lresult: [IN] Int
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
-
-    cjprod!(n, m, gotj, jtrans, x, vector, lvector, result, lresult, cutest_lib)
+    result = cjprod(n, m, gotj, jtrans, x, vector, lvector, lresult)
 
   - n:       [IN] Int
   - m:       [IN] Int
@@ -6403,7 +6214,18 @@ Usage:
   - lvector: [IN] Int
   - result:  [OUT] Array{Float64, 1}
   - lresult: [IN] Int
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+
+    cjprod!(n, m, gotj, jtrans, x, vector, lvector, result, lresult)
+
+  - n:       [IN] Int
+  - m:       [IN] Int
+  - gotj:    [IN] Bool
+  - jtrans:  [IN] Bool
+  - x:       [IN] Array{Float64, 1}
+  - vector:  [IN] Array{Float64, 1}
+  - lvector: [IN] Int
+  - result:  [OUT] Array{Float64, 1}
+  - lresult: [IN] Int
 
     result = cjprod(nlp, gotj, jtrans, x, vector, lvector, lresult)
 
@@ -6441,14 +6263,13 @@ errors. For more information, run the shell command
 
 Usage:
 
-    uterminate(io_err, cutest_lib)
+    uterminate(io_err)
 
   - io_err:  [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    uterminate(, cutest_lib)
 
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+    uterminate()
+
 
 """
 uterminate
@@ -6464,14 +6285,13 @@ errors. For more information, run the shell command
 
 Usage:
 
-    cterminate(io_err, cutest_lib)
+    cterminate(io_err)
 
   - io_err:  [OUT] Array{Cint, 1}
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
 
-    cterminate(, cutest_lib)
 
-  - cutest_lib: [IN] ASCIIString or Ptr{Void} with CUTEst library from sifdecode
+    cterminate()
+
 
 """
 cterminate

--- a/src/specialized_interface.jl
+++ b/src/specialized_interface.jl
@@ -13,28 +13,28 @@ export usetup!, csetup!, udimen!, udimsh!, udimse!, uvartype!,
     ccifg!, ccifsg!, cgrdh!, cdh!, csh!, cshc!, ceh!, cidh!, cish!,
     csgrsh!, csgreh!, chprod!, chcprod!, cjprod!, uterminate!, cterminate!
 
-function usetup(input::Int, out::Int, io_buffer::Int, n::Int, cutest_lib)
+function usetup(input::Int, out::Int, io_buffer::Int, n::Int)
   io_err = Cint[0]
   x = Array(Cdouble, n)
   x_l = Array(Cdouble, n)
   x_u = Array(Cdouble, n)
   usetup(io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n], x,
-    x_l, x_u, cutest_lib)
+    x_l, x_u)
   @cutest_error
   return x, x_l, x_u
 end
 
 function usetup!(input::Int, out::Int, io_buffer::Int, n::Int, x::Array{Float64, 1},
-    x_l::Array{Float64, 1}, x_u::Array{Float64, 1}, cutest_lib)
+    x_l::Array{Float64, 1}, x_u::Array{Float64, 1})
   io_err = Cint[0]
   usetup(io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n], x,
-    x_l, x_u, cutest_lib)
+    x_l, x_u)
   @cutest_error
   return
 end
 
 function csetup(input::Int, out::Int, io_buffer::Int, n::Int, m::Int, e_order::Int,
-    l_order::Int, v_order::Int, cutest_lib)
+    l_order::Int, v_order::Int)
   io_err = Cint[0]
   x = Array(Cdouble, n)
   x_l = Array(Cdouble, n)
@@ -46,7 +46,7 @@ function csetup(input::Int, out::Int, io_buffer::Int, n::Int, m::Int, e_order::I
   linear = Array(Cint, m)
   csetup(io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n],
     Cint[m], x, x_l, x_u, y, c_l, c_u, equatn, linear, Cint[e_order],
-    Cint[l_order], Cint[v_order], cutest_lib)
+    Cint[l_order], Cint[v_order])
   @cutest_error
   return x, x_l, x_u, y, c_l, c_u, equatn, linear
 end
@@ -55,53 +55,51 @@ function csetup!(input::Int, out::Int, io_buffer::Int, n::Int, m::Int,
     x::Array{Float64, 1}, x_l::Array{Float64, 1}, x_u::Array{Float64, 1},
     y::Array{Float64, 1}, c_l::Array{Float64, 1}, c_u::Array{Float64, 1},
     equatn::Array{Bool, 1}, linear::Array{Bool, 1}, e_order::Int,
-    l_order::Int, v_order::Int, cutest_lib)
+    l_order::Int, v_order::Int)
   io_err = Cint[0]
   csetup(io_err, Cint[input], Cint[out], Cint[io_buffer], Cint[n],
     Cint[m], x, x_l, x_u, y, c_l, c_u, equatn, linear, Cint[e_order],
-    Cint[l_order], Cint[v_order], cutest_lib)
+    Cint[l_order], Cint[v_order])
   @cutest_error
   return
 end
 
-function udimen(input::Int, cutest_lib)
+function udimen(input::Int)
   io_err = Cint[0]
   n = Cint[0]
-  udimen(io_err, Cint[input], n, cutest_lib)
+  udimen(io_err, Cint[input], n)
   @cutest_error
   return n[1]
 end
 
-function udimsh(cutest_lib)
-  io_err = Cint[0]
+function udimsh()  io_err = Cint[0]
   nnzh = Cint[0]
-  udimsh(io_err, nnzh, cutest_lib)
+  udimsh(io_err, nnzh)
   @cutest_error
   return nnzh[1]
 end
 
-function udimse(cutest_lib)
-  io_err = Cint[0]
+function udimse()  io_err = Cint[0]
   ne = Cint[0]
   he_val_ne = Cint[0]
   he_row_ne = Cint[0]
-  udimse(io_err, ne, he_val_ne, he_row_ne, cutest_lib)
+  udimse(io_err, ne, he_val_ne, he_row_ne)
   @cutest_error
   return ne[1], he_val_ne[1], he_row_ne[1]
 end
 
-function uvartype(n::Int, cutest_lib)
+function uvartype(n::Int)
   io_err = Cint[0]
   x_type = Array(Cint, n)
-  uvartype(io_err, Cint[n], x_type, cutest_lib)
+  uvartype(io_err, Cint[n], x_type)
   @cutest_error
   return x_type
 end
 
-function uvartype!(n::Int, x_type::Array{Int, 1}, cutest_lib)
+function uvartype!(n::Int, x_type::Array{Int, 1})
   io_err = Cint[0]
   x_type_cp = Array(Cint, n)
-  uvartype(io_err, Cint[n], x_type_cp, cutest_lib)
+  uvartype(io_err, Cint[n], x_type_cp)
   @cutest_error
   for i = 1:n
     x_type[i] = x_type_cp[i]
@@ -109,42 +107,41 @@ function uvartype!(n::Int, x_type::Array{Int, 1}, cutest_lib)
   return
 end
 
-function uvartype!(n::Int, x_type::Array{Cint, 1}, cutest_lib)
+function uvartype!(n::Int, x_type::Array{Cint, 1})
   io_err = Cint[0]
-  uvartype(io_err, Cint[n], x_type, cutest_lib)
+  uvartype(io_err, Cint[n], x_type)
   @cutest_error
   return
 end
 
-function unames(n::Int, cutest_lib)
+function unames(n::Int)
   io_err = Cint[0]
   pname = Cchar[0]
   vname = Array(Cchar, n)
-  unames(io_err, Cint[n], pname, vname, cutest_lib)
+  unames(io_err, Cint[n], pname, vname)
   @cutest_error
   return pname[1], vname
 end
 
-function unames!(n::Int, vname::Array{UInt8, 1}, cutest_lib)
+function unames!(n::Int, vname::Array{UInt8, 1})
   io_err = Cint[0]
   pname = Cchar[0]
-  unames(io_err, Cint[n], pname, vname, cutest_lib)
+  unames(io_err, Cint[n], pname, vname)
   @cutest_error
   return pname[1]
 end
 
-function ureport(cutest_lib)
-  io_err = Cint[0]
+function ureport()  io_err = Cint[0]
   calls = Array(Cdouble, 4)
   time = Array(Cdouble, 2)
-  ureport(io_err, calls, time, cutest_lib)
+  ureport(io_err, calls, time)
   @cutest_error
   return calls, time
 end
 
-function ureport!(calls::Array{Float64, 1}, time::Array{Float64, 1}, cutest_lib)
+function ureport!(calls::Array{Float64, 1}, time::Array{Float64, 1})
   io_err = Cint[0]
-  ureport(io_err, calls, time, cutest_lib)
+  ureport(io_err, calls, time)
   @cutest_error
   return
 end
@@ -153,62 +150,58 @@ function ureport(nlp::CUTEstModel)
   io_err = Cint[0]
   calls = Array(Cdouble, 4)
   time = Array(Cdouble, 2)
-  ureport(io_err, calls, time, nlp.cutest_lib)
+  ureport(io_err, calls, time)
   @cutest_error
   return calls, time
 end
 
 function ureport!(nlp::CUTEstModel, calls::Array{Float64, 1}, time::Array{Float64, 1})
   io_err = Cint[0]
-  ureport(io_err, calls, time, nlp.cutest_lib)
+  ureport(io_err, calls, time)
   @cutest_error
   return
 end
 
-function cdimen(input::Int, cutest_lib)
+function cdimen(input::Int)
   io_err = Cint[0]
   n = Cint[0]
   m = Cint[0]
-  cdimen(io_err, Cint[input], n, m, cutest_lib)
+  cdimen(io_err, Cint[input], n, m)
   @cutest_error
   return n[1], m[1]
 end
 
-function cdimsj(cutest_lib)
-  io_err = Cint[0]
+function cdimsj()  io_err = Cint[0]
   nnzj = Cint[0]
-  cdimsj(io_err, nnzj, cutest_lib)
+  cdimsj(io_err, nnzj)
   @cutest_error
   return nnzj[1]
 end
 
-function cdimsh(cutest_lib)
-  io_err = Cint[0]
+function cdimsh()  io_err = Cint[0]
   nnzh = Cint[0]
-  cdimsh(io_err, nnzh, cutest_lib)
+  cdimsh(io_err, nnzh)
   @cutest_error
   return nnzh[1]
 end
 
-function cdimse(cutest_lib)
-  io_err = Cint[0]
+function cdimse()  io_err = Cint[0]
   ne = Cint[0]
   he_val_ne = Cint[0]
   he_row_ne = Cint[0]
-  cdimse(io_err, ne, he_val_ne, he_row_ne, cutest_lib)
+  cdimse(io_err, ne, he_val_ne, he_row_ne)
   @cutest_error
   return ne[1], he_val_ne[1], he_row_ne[1]
 end
 
-function cstats(cutest_lib)
-  io_err = Cint[0]
+function cstats()  io_err = Cint[0]
   nonlinear_variables_objective = Cint[0]
   nonlinear_variables_constraints = Cint[0]
   equality_constraints = Cint[0]
   linear_constraints = Cint[0]
   cstats(io_err, nonlinear_variables_objective,
     nonlinear_variables_constraints, equality_constraints,
-    linear_constraints, cutest_lib)
+    linear_constraints)
   @cutest_error
   return nonlinear_variables_objective[1], nonlinear_variables_constraints[1], equality_constraints[1], linear_constraints[1]
 end
@@ -221,23 +214,23 @@ function cstats(nlp::CUTEstModel)
   linear_constraints = Cint[0]
   cstats(io_err, nonlinear_variables_objective,
     nonlinear_variables_constraints, equality_constraints,
-    linear_constraints, nlp.cutest_lib)
+    linear_constraints)
   @cutest_error
   return nonlinear_variables_objective[1], nonlinear_variables_constraints[1], equality_constraints[1], linear_constraints[1]
 end
 
-function cvartype(n::Int, cutest_lib)
+function cvartype(n::Int)
   io_err = Cint[0]
   x_type = Array(Cint, n)
-  cvartype(io_err, Cint[n], x_type, cutest_lib)
+  cvartype(io_err, Cint[n], x_type)
   @cutest_error
   return x_type
 end
 
-function cvartype!(n::Int, x_type::Array{Int, 1}, cutest_lib)
+function cvartype!(n::Int, x_type::Array{Int, 1})
   io_err = Cint[0]
   x_type_cp = Array(Cint, n)
-  cvartype(io_err, Cint[n], x_type_cp, cutest_lib)
+  cvartype(io_err, Cint[n], x_type_cp)
   @cutest_error
   for i = 1:n
     x_type[i] = x_type_cp[i]
@@ -245,28 +238,27 @@ function cvartype!(n::Int, x_type::Array{Int, 1}, cutest_lib)
   return
 end
 
-function cvartype!(n::Int, x_type::Array{Cint, 1}, cutest_lib)
+function cvartype!(n::Int, x_type::Array{Cint, 1})
   io_err = Cint[0]
-  cvartype(io_err, Cint[n], x_type, cutest_lib)
+  cvartype(io_err, Cint[n], x_type)
   @cutest_error
   return
 end
 
-function cnames(n::Int, m::Int, cutest_lib)
+function cnames(n::Int, m::Int)
   io_err = Cint[0]
   pname = Cchar[0]
   vname = Array(Cchar, n)
   cname = Array(Cchar, m)
-  cnames(io_err, Cint[n], Cint[m], pname, vname, cname, cutest_lib)
+  cnames(io_err, Cint[n], Cint[m], pname, vname, cname)
   @cutest_error
   return pname[1], vname, cname
 end
 
-function cnames!(n::Int, m::Int, vname::Array{UInt8, 1}, cname::Array{UInt8, 1},
-    cutest_lib)
+function cnames!(n::Int, m::Int, vname::Array{UInt8, 1}, cname::Array{UInt8, 1})
   io_err = Cint[0]
   pname = Cchar[0]
-  cnames(io_err, Cint[n], Cint[m], pname, vname, cname, cutest_lib)
+  cnames(io_err, Cint[n], Cint[m], pname, vname, cname)
   @cutest_error
   return pname[1]
 end
@@ -278,8 +270,7 @@ function cnames(nlp::CUTEstModel)
   pname = Cchar[0]
   vname = Array(Cchar, n)
   cname = Array(Cchar, m)
-  cnames(io_err, Cint[n], Cint[m], pname, vname, cname,
-    nlp.cutest_lib)
+  cnames(io_err, Cint[n], Cint[m], pname, vname, cname)
   @cutest_error
   return pname[1], vname, cname
 end
@@ -289,24 +280,22 @@ function cnames!(nlp::CUTEstModel, vname::Array{UInt8, 1}, cname::Array{UInt8, 1
   n = nlp.meta.nvar
   m = nlp.meta.ncon
   pname = Cchar[0]
-  cnames(io_err, Cint[n], Cint[m], pname, vname, cname,
-    nlp.cutest_lib)
+  cnames(io_err, Cint[n], Cint[m], pname, vname, cname)
   @cutest_error
   return pname[1]
 end
 
-function creport(cutest_lib)
-  io_err = Cint[0]
+function creport()  io_err = Cint[0]
   calls = Array(Cdouble, 7)
   time = Array(Cdouble, 2)
-  creport(io_err, calls, time, cutest_lib)
+  creport(io_err, calls, time)
   @cutest_error
   return calls, time
 end
 
-function creport!(calls::Array{Float64, 1}, time::Array{Float64, 1}, cutest_lib)
+function creport!(calls::Array{Float64, 1}, time::Array{Float64, 1})
   io_err = Cint[0]
-  creport(io_err, calls, time, cutest_lib)
+  creport(io_err, calls, time)
   @cutest_error
   return
 end
@@ -315,29 +304,29 @@ function creport(nlp::CUTEstModel)
   io_err = Cint[0]
   calls = Array(Cdouble, 7)
   time = Array(Cdouble, 2)
-  creport(io_err, calls, time, nlp.cutest_lib)
+  creport(io_err, calls, time)
   @cutest_error
   return calls, time
 end
 
 function creport!(nlp::CUTEstModel, calls::Array{Float64, 1}, time::Array{Float64, 1})
   io_err = Cint[0]
-  creport(io_err, calls, time, nlp.cutest_lib)
+  creport(io_err, calls, time)
   @cutest_error
   return
 end
 
-function connames(m::Int, cutest_lib)
+function connames(m::Int)
   io_err = Cint[0]
   cname = Array(Cchar, m)
-  connames(io_err, Cint[m], cname, cutest_lib)
+  connames(io_err, Cint[m], cname)
   @cutest_error
   return cname
 end
 
-function connames!(m::Int, cname::Array{UInt8, 1}, cutest_lib)
+function connames!(m::Int, cname::Array{UInt8, 1})
   io_err = Cint[0]
-  connames(io_err, Cint[m], cname, cutest_lib)
+  connames(io_err, Cint[m], cname)
   @cutest_error
   return
 end
@@ -346,7 +335,7 @@ function connames(nlp::CUTEstModel)
   io_err = Cint[0]
   m = nlp.meta.ncon
   cname = Array(Cchar, m)
-  connames(io_err, Cint[m], cname, nlp.cutest_lib)
+  connames(io_err, Cint[m], cname)
   @cutest_error
   return cname
 end
@@ -354,15 +343,15 @@ end
 function connames!(nlp::CUTEstModel, cname::Array{UInt8, 1})
   io_err = Cint[0]
   m = nlp.meta.ncon
-  connames(io_err, Cint[m], cname, nlp.cutest_lib)
+  connames(io_err, Cint[m], cname)
   @cutest_error
   return
 end
 
-function pname(input::Int, cutest_lib)
+function pname(input::Int)
   io_err = Cint[0]
   pname = Cchar[0]
-  pname(io_err, Cint[input], pname, cutest_lib)
+  pname(io_err, Cint[input], pname)
   @cutest_error
   return pname[1]
 end
@@ -370,15 +359,14 @@ end
 function pname(nlp::CUTEstModel, input::Int)
   io_err = Cint[0]
   pname = Cchar[0]
-  pname(io_err, Cint[input], pname, nlp.cutest_lib)
+  pname(io_err, Cint[input], pname)
   @cutest_error
   return pname[1]
 end
 
-function probname(cutest_lib)
-  io_err = Cint[0]
+function probname()  io_err = Cint[0]
   pname = Cchar[0]
-  probname(io_err, pname, cutest_lib)
+  probname(io_err, pname)
   @cutest_error
   return pname[1]
 end
@@ -386,30 +374,30 @@ end
 function probname(nlp::CUTEstModel)
   io_err = Cint[0]
   pname = Cchar[0]
-  probname(io_err, pname, nlp.cutest_lib)
+  probname(io_err, pname)
   @cutest_error
   return pname[1]
 end
 
-function varnames(n::Int, cutest_lib)
+function varnames(n::Int)
   io_err = Cint[0]
   vname = Array(Cchar, n)
-  varnames(io_err, Cint[n], vname, cutest_lib)
+  varnames(io_err, Cint[n], vname)
   @cutest_error
   return vname
 end
 
-function varnames!(n::Int, vname::Array{UInt8, 1}, cutest_lib)
+function varnames!(n::Int, vname::Array{UInt8, 1})
   io_err = Cint[0]
-  varnames(io_err, Cint[n], vname, cutest_lib)
+  varnames(io_err, Cint[n], vname)
   @cutest_error
   return
 end
 
-function ufn(n::Int, x::Array{Float64, 1}, cutest_lib)
+function ufn(n::Int, x::Array{Float64, 1})
   io_err = Cint[0]
   f = Cdouble[0]
-  ufn(io_err, Cint[n], x, f, cutest_lib)
+  ufn(io_err, Cint[n], x, f)
   @cutest_error
   return f[1]
 end
@@ -418,22 +406,22 @@ function ufn(nlp::CUTEstModel, x::Array{Float64, 1})
   io_err = Cint[0]
   n = nlp.meta.nvar
   f = Cdouble[0]
-  ufn(io_err, Cint[n], x, f, nlp.cutest_lib)
+  ufn(io_err, Cint[n], x, f)
   @cutest_error
   return f[1]
 end
 
-function ugr(n::Int, x::Array{Float64, 1}, cutest_lib)
+function ugr(n::Int, x::Array{Float64, 1})
   io_err = Cint[0]
   g = Array(Cdouble, n)
-  ugr(io_err, Cint[n], x, g, cutest_lib)
+  ugr(io_err, Cint[n], x, g)
   @cutest_error
   return g
 end
 
-function ugr!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, cutest_lib)
+function ugr!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1})
   io_err = Cint[0]
-  ugr(io_err, Cint[n], x, g, cutest_lib)
+  ugr(io_err, Cint[n], x, g)
   @cutest_error
   return
 end
@@ -442,7 +430,7 @@ function ugr(nlp::CUTEstModel, x::Array{Float64, 1})
   io_err = Cint[0]
   n = nlp.meta.nvar
   g = Array(Cdouble, n)
-  ugr(io_err, Cint[n], x, g, nlp.cutest_lib)
+  ugr(io_err, Cint[n], x, g)
   @cutest_error
   return g
 end
@@ -450,25 +438,24 @@ end
 function ugr!(nlp::CUTEstModel, x::Array{Float64, 1}, g::Array{Float64, 1})
   io_err = Cint[0]
   n = nlp.meta.nvar
-  ugr(io_err, Cint[n], x, g, nlp.cutest_lib)
+  ugr(io_err, Cint[n], x, g)
   @cutest_error
   return
 end
 
-function uofg(n::Int, x::Array{Float64, 1}, grad::Bool, cutest_lib)
+function uofg(n::Int, x::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   g = Array(Cdouble, n)
-  uofg(io_err, Cint[n], x, f, g, Cint[grad], cutest_lib)
+  uofg(io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1], g
 end
 
-function uofg!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, grad::Bool,
-    cutest_lib)
+function uofg!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
-  uofg(io_err, Cint[n], x, f, g, Cint[grad], cutest_lib)
+  uofg(io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1]
 end
@@ -478,7 +465,7 @@ function uofg(nlp::CUTEstModel, x::Array{Float64, 1}, grad::Bool)
   n = nlp.meta.nvar
   f = Cdouble[0]
   g = Array(Cdouble, n)
-  uofg(io_err, Cint[n], x, f, g, Cint[grad], nlp.cutest_lib)
+  uofg(io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1], g
 end
@@ -488,28 +475,27 @@ function uofg!(nlp::CUTEstModel, x::Array{Float64, 1}, g::Array{Float64, 1},
   io_err = Cint[0]
   n = nlp.meta.nvar
   f = Cdouble[0]
-  uofg(io_err, Cint[n], x, f, g, Cint[grad], nlp.cutest_lib)
+  uofg(io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1]
 end
 
-function ubandh(n::Int, x::Array{Float64, 1}, semibandwidth::Int, lbandh::Int,
-    cutest_lib)
+function ubandh(n::Int, x::Array{Float64, 1}, semibandwidth::Int, lbandh::Int)
   io_err = Cint[0]
   h_band = Array(Cdouble, lbandh - 0 + 1, n)
   max_semibandwidth = Cint[0]
   ubandh(io_err, Cint[n], x, Cint[semibandwidth], h_band,
-    Cint[lbandh], max_semibandwidth, cutest_lib)
+    Cint[lbandh], max_semibandwidth)
   @cutest_error
   return h_band, max_semibandwidth[1]
 end
 
 function ubandh!(n::Int, x::Array{Float64, 1}, semibandwidth::Int,
-    h_band::Array{Float64, 2}, lbandh::Int, cutest_lib)
+    h_band::Array{Float64, 2}, lbandh::Int)
   io_err = Cint[0]
   max_semibandwidth = Cint[0]
   ubandh(io_err, Cint[n], x, Cint[semibandwidth], h_band,
-    Cint[lbandh], max_semibandwidth, cutest_lib)
+    Cint[lbandh], max_semibandwidth)
   @cutest_error
   return max_semibandwidth[1]
 end
@@ -521,7 +507,7 @@ function ubandh(nlp::CUTEstModel, x::Array{Float64, 1}, semibandwidth::Int,
   h_band = Array(Cdouble, lbandh - 0 + 1, n)
   max_semibandwidth = Cint[0]
   ubandh(io_err, Cint[n], x, Cint[semibandwidth], h_band,
-    Cint[lbandh], max_semibandwidth, nlp.cutest_lib)
+    Cint[lbandh], max_semibandwidth)
   @cutest_error
   return h_band, max_semibandwidth[1]
 end
@@ -532,23 +518,22 @@ function ubandh!(nlp::CUTEstModel, x::Array{Float64, 1}, semibandwidth::Int,
   n = nlp.meta.nvar
   max_semibandwidth = Cint[0]
   ubandh(io_err, Cint[n], x, Cint[semibandwidth], h_band,
-    Cint[lbandh], max_semibandwidth, nlp.cutest_lib)
+    Cint[lbandh], max_semibandwidth)
   @cutest_error
   return max_semibandwidth[1]
 end
 
-function udh(n::Int, x::Array{Float64, 1}, lh1::Int, cutest_lib)
+function udh(n::Int, x::Array{Float64, 1}, lh1::Int)
   io_err = Cint[0]
   h = Array(Cdouble, lh1, n)
-  udh(io_err, Cint[n], x, Cint[lh1], h, cutest_lib)
+  udh(io_err, Cint[n], x, Cint[lh1], h)
   @cutest_error
   return h
 end
 
-function udh!(n::Int, x::Array{Float64, 1}, lh1::Int, h::Array{Float64, 2},
-    cutest_lib)
+function udh!(n::Int, x::Array{Float64, 1}, lh1::Int, h::Array{Float64, 2})
   io_err = Cint[0]
-  udh(io_err, Cint[n], x, Cint[lh1], h, cutest_lib)
+  udh(io_err, Cint[n], x, Cint[lh1], h)
   @cutest_error
   return
 end
@@ -557,7 +542,7 @@ function udh(nlp::CUTEstModel, x::Array{Float64, 1}, lh1::Int)
   io_err = Cint[0]
   n = nlp.meta.nvar
   h = Array(Cdouble, lh1, n)
-  udh(io_err, Cint[n], x, Cint[lh1], h, nlp.cutest_lib)
+  udh(io_err, Cint[n], x, Cint[lh1], h)
   @cutest_error
   return h
 end
@@ -566,31 +551,29 @@ function udh!(nlp::CUTEstModel, x::Array{Float64, 1}, lh1::Int, h::Array{Float64
     2})
   io_err = Cint[0]
   n = nlp.meta.nvar
-  udh(io_err, Cint[n], x, Cint[lh1], h, nlp.cutest_lib)
+  udh(io_err, Cint[n], x, Cint[lh1], h)
   @cutest_error
   return
 end
 
-function ush(n::Int, x::Array{Float64, 1}, lh::Int, cutest_lib)
+function ush(n::Int, x::Array{Float64, 1}, lh::Int)
   io_err = Cint[0]
   nnzh = Cint[0]
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col,
-    cutest_lib)
+  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
 end
 
 function ush!(n::Int, x::Array{Float64, 1}, lh::Int, h_val::Array{Float64, 1},
-    h_row::Array{Int, 1}, h_col::Array{Int, 1}, cutest_lib)
+    h_row::Array{Int, 1}, h_col::Array{Int, 1})
   io_err = Cint[0]
   nnzh = Cint[0]
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
-  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row_cp, h_col_cp,
-    cutest_lib)
+  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row_cp, h_col_cp)
   @cutest_error
   for i = 1:lh
     h_row[i] = h_row_cp[i]
@@ -602,11 +585,10 @@ function ush!(n::Int, x::Array{Float64, 1}, lh::Int, h_val::Array{Float64, 1},
 end
 
 function ush!(n::Int, x::Array{Float64, 1}, lh::Int, h_val::Array{Float64, 1},
-    h_row::Array{Cint, 1}, h_col::Array{Cint, 1}, cutest_lib)
+    h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   io_err = Cint[0]
   nnzh = Cint[0]
-  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col,
-    cutest_lib)
+  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzh[1]
 end
@@ -619,8 +601,7 @@ function ush(nlp::CUTEstModel, x::Array{Float64, 1})
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col,
-    nlp.cutest_lib)
+  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
 end
@@ -633,8 +614,7 @@ function ush!(nlp::CUTEstModel, x::Array{Float64, 1}, h_val::Array{Float64, 1},
   lh = nlp.meta.nnzh
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
-  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row_cp, h_col_cp,
-    nlp.cutest_lib)
+  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row_cp, h_col_cp)
   @cutest_error
   for i = 1:lh
     h_row[i] = h_row_cp[i]
@@ -651,14 +631,13 @@ function ush!(nlp::CUTEstModel, x::Array{Float64, 1}, h_val::Array{Float64, 1},
   n = nlp.meta.nvar
   nnzh = Cint[0]
   lh = nlp.meta.nnzh
-  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col,
-    nlp.cutest_lib)
+  ush(io_err, Cint[n], x, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzh[1]
 end
 
 function ueh(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
-    lhe_val::Int, byrows::Bool, cutest_lib)
+    lhe_val::Int, byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
   he_row_ptr = Array(Cint, lhe_ptr)
@@ -666,15 +645,14 @@ function ueh(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
   he_row = Array(Cint, lhe_row)
   he_val = Array(Cdouble, lhe_val)
   ueh(io_err, Cint[n], x, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
-    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows],
-    cutest_lib)
+    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
   return ne[1], he_row_ptr, he_val_ptr, he_row, he_val
 end
 
 function ueh!(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, he_row_ptr::Array{Int,
     1}, he_val_ptr::Array{Int, 1}, lhe_row::Int, he_row::Array{Int, 1},
-    lhe_val::Int, he_val::Array{Float64, 1}, byrows::Bool, cutest_lib)
+    lhe_val::Int, he_val::Array{Float64, 1}, byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
   he_row_ptr_cp = Array(Cint, lhe_ptr)
@@ -682,7 +660,7 @@ function ueh!(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, he_row_ptr::Array{Int,
   he_row_cp = Array(Cint, lhe_row)
   ueh(io_err, Cint[n], x, ne, Cint[lhe_ptr], he_row_ptr_cp,
     he_val_ptr_cp, Cint[lhe_row], he_row_cp, Cint[lhe_val], he_val,
-    Cint[byrows], cutest_lib)
+    Cint[byrows])
   @cutest_error
   for i = 1:lhe_ptr
     he_row_ptr[i] = he_row_ptr_cp[i]
@@ -698,12 +676,11 @@ end
 
 function ueh!(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, he_row_ptr::Array{Cint,
     1}, he_val_ptr::Array{Cint, 1}, lhe_row::Int, he_row::Array{Cint, 1},
-    lhe_val::Int, he_val::Array{Float64, 1}, byrows::Bool, cutest_lib)
+    lhe_val::Int, he_val::Array{Float64, 1}, byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
   ueh(io_err, Cint[n], x, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
-    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows],
-    cutest_lib)
+    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
   return ne[1]
 end
@@ -718,8 +695,7 @@ function ueh(nlp::CUTEstModel, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
   he_row = Array(Cint, lhe_row)
   he_val = Array(Cdouble, lhe_val)
   ueh(io_err, Cint[n], x, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
-    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows],
-    nlp.cutest_lib)
+    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
   return ne[1], he_row_ptr, he_val_ptr, he_row, he_val
 end
@@ -736,7 +712,7 @@ function ueh!(nlp::CUTEstModel, x::Array{Float64, 1}, lhe_ptr::Int,
   he_row_cp = Array(Cint, lhe_row)
   ueh(io_err, Cint[n], x, ne, Cint[lhe_ptr], he_row_ptr_cp,
     he_val_ptr_cp, Cint[lhe_row], he_row_cp, Cint[lhe_val], he_val,
-    Cint[byrows], nlp.cutest_lib)
+    Cint[byrows])
   @cutest_error
   for i = 1:lhe_ptr
     he_row_ptr[i] = he_row_ptr_cp[i]
@@ -758,25 +734,24 @@ function ueh!(nlp::CUTEstModel, x::Array{Float64, 1}, lhe_ptr::Int,
   n = nlp.meta.nvar
   ne = Cint[0]
   ueh(io_err, Cint[n], x, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
-    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows],
-    nlp.cutest_lib)
+    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
   return ne[1]
 end
 
-function ugrdh(n::Int, x::Array{Float64, 1}, lh1::Int, cutest_lib)
+function ugrdh(n::Int, x::Array{Float64, 1}, lh1::Int)
   io_err = Cint[0]
   g = Array(Cdouble, n)
   h = Array(Cdouble, lh1, n)
-  ugrdh(io_err, Cint[n], x, g, Cint[lh1], h, cutest_lib)
+  ugrdh(io_err, Cint[n], x, g, Cint[lh1], h)
   @cutest_error
   return g, h
 end
 
 function ugrdh!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lh1::Int,
-    h::Array{Float64, 2}, cutest_lib)
+    h::Array{Float64, 2})
   io_err = Cint[0]
-  ugrdh(io_err, Cint[n], x, g, Cint[lh1], h, cutest_lib)
+  ugrdh(io_err, Cint[n], x, g, Cint[lh1], h)
   @cutest_error
   return
 end
@@ -786,7 +761,7 @@ function ugrdh(nlp::CUTEstModel, x::Array{Float64, 1}, lh1::Int)
   n = nlp.meta.nvar
   g = Array(Cdouble, n)
   h = Array(Cdouble, lh1, n)
-  ugrdh(io_err, Cint[n], x, g, Cint[lh1], h, nlp.cutest_lib)
+  ugrdh(io_err, Cint[n], x, g, Cint[lh1], h)
   @cutest_error
   return g, h
 end
@@ -795,33 +770,31 @@ function ugrdh!(nlp::CUTEstModel, x::Array{Float64, 1}, g::Array{Float64, 1},
     lh1::Int, h::Array{Float64, 2})
   io_err = Cint[0]
   n = nlp.meta.nvar
-  ugrdh(io_err, Cint[n], x, g, Cint[lh1], h, nlp.cutest_lib)
+  ugrdh(io_err, Cint[n], x, g, Cint[lh1], h)
   @cutest_error
   return
 end
 
-function ugrsh(n::Int, x::Array{Float64, 1}, lh::Int, cutest_lib)
+function ugrsh(n::Int, x::Array{Float64, 1}, lh::Int)
   io_err = Cint[0]
   g = Array(Cdouble, n)
   nnzh = Cint[0]
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col,
-    cutest_lib)
+  ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return g, nnzh[1], h_val, h_row, h_col
 end
 
 function ugrsh!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lh::Int,
-    h_val::Array{Float64, 1}, h_row::Array{Int, 1}, h_col::Array{Int, 1},
-    cutest_lib)
+    h_val::Array{Float64, 1}, h_row::Array{Int, 1}, h_col::Array{Int, 1})
   io_err = Cint[0]
   nnzh = Cint[0]
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
   ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row_cp,
-    h_col_cp, cutest_lib)
+    h_col_cp)
   @cutest_error
   for i = 1:lh
     h_row[i] = h_row_cp[i]
@@ -834,11 +807,10 @@ end
 
 function ugrsh!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lh::Int,
     h_val::Array{Float64, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
-    1}, cutest_lib)
+    1})
   io_err = Cint[0]
   nnzh = Cint[0]
-  ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col,
-    cutest_lib)
+  ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzh[1]
 end
@@ -852,8 +824,7 @@ function ugrsh(nlp::CUTEstModel, x::Array{Float64, 1})
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
-  ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col,
-    nlp.cutest_lib)
+  ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return g, nnzh[1], h_val, h_row, h_col
 end
@@ -867,7 +838,7 @@ function ugrsh!(nlp::CUTEstModel, x::Array{Float64, 1}, g::Array{Float64, 1},
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
   ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row_cp,
-    h_col_cp, nlp.cutest_lib)
+    h_col_cp)
   @cutest_error
   for i = 1:lh
     h_row[i] = h_row_cp[i]
@@ -885,14 +856,13 @@ function ugrsh!(nlp::CUTEstModel, x::Array{Float64, 1}, g::Array{Float64, 1},
   n = nlp.meta.nvar
   nnzh = Cint[0]
   lh = nlp.meta.nnzh
-  ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col,
-    nlp.cutest_lib)
+  ugrsh(io_err, Cint[n], x, g, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzh[1]
 end
 
 function ugreh(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
-    lhe_val::Int, byrows::Bool, cutest_lib)
+    lhe_val::Int, byrows::Bool)
   io_err = Cint[0]
   g = Array(Cdouble, n)
   ne = Cint[0]
@@ -902,7 +872,7 @@ function ugreh(n::Int, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::Int,
   he_val = Array(Cdouble, lhe_val)
   ugreh(io_err, Cint[n], x, g, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
-    Cint[byrows], cutest_lib)
+    Cint[byrows])
   @cutest_error
   return g, ne[1], he_row_ptr, he_val_ptr, he_row, he_val
 end
@@ -910,7 +880,7 @@ end
 function ugreh!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lhe_ptr::Int,
     he_row_ptr::Array{Int, 1}, he_val_ptr::Array{Int, 1}, lhe_row::Int,
     he_row::Array{Int, 1}, lhe_val::Int, he_val::Array{Float64, 1},
-    byrows::Bool, cutest_lib)
+    byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
   he_row_ptr_cp = Array(Cint, lhe_ptr)
@@ -918,7 +888,7 @@ function ugreh!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lhe_ptr::Int
   he_row_cp = Array(Cint, lhe_row)
   ugreh(io_err, Cint[n], x, g, ne, Cint[lhe_ptr], he_row_ptr_cp,
     he_val_ptr_cp, Cint[lhe_row], he_row_cp, Cint[lhe_val], he_val,
-    Cint[byrows], cutest_lib)
+    Cint[byrows])
   @cutest_error
   for i = 1:lhe_ptr
     he_row_ptr[i] = he_row_ptr_cp[i]
@@ -935,12 +905,12 @@ end
 function ugreh!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, lhe_ptr::Int,
     he_row_ptr::Array{Cint, 1}, he_val_ptr::Array{Cint, 1}, lhe_row::Int,
     he_row::Array{Cint, 1}, lhe_val::Int, he_val::Array{Float64, 1},
-    byrows::Bool, cutest_lib)
+    byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
   ugreh(io_err, Cint[n], x, g, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
-    Cint[byrows], cutest_lib)
+    Cint[byrows])
   @cutest_error
   return ne[1]
 end
@@ -957,7 +927,7 @@ function ugreh(nlp::CUTEstModel, x::Array{Float64, 1}, lhe_ptr::Int, lhe_row::In
   he_val = Array(Cdouble, lhe_val)
   ugreh(io_err, Cint[n], x, g, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
-    Cint[byrows], nlp.cutest_lib)
+    Cint[byrows])
   @cutest_error
   return g, ne[1], he_row_ptr, he_val_ptr, he_row, he_val
 end
@@ -974,7 +944,7 @@ function ugreh!(nlp::CUTEstModel, x::Array{Float64, 1}, g::Array{Float64, 1},
   he_row_cp = Array(Cint, lhe_row)
   ugreh(io_err, Cint[n], x, g, ne, Cint[lhe_ptr], he_row_ptr_cp,
     he_val_ptr_cp, Cint[lhe_row], he_row_cp, Cint[lhe_val], he_val,
-    Cint[byrows], nlp.cutest_lib)
+    Cint[byrows])
   @cutest_error
   for i = 1:lhe_ptr
     he_row_ptr[i] = he_row_ptr_cp[i]
@@ -997,24 +967,23 @@ function ugreh!(nlp::CUTEstModel, x::Array{Float64, 1}, g::Array{Float64, 1},
   ne = Cint[0]
   ugreh(io_err, Cint[n], x, g, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
-    Cint[byrows], nlp.cutest_lib)
+    Cint[byrows])
   @cutest_error
   return ne[1]
 end
 
-function uhprod(n::Int, goth::Bool, x::Array{Float64, 1}, vector::Array{Float64, 1},
-    cutest_lib)
+function uhprod(n::Int, goth::Bool, x::Array{Float64, 1}, vector::Array{Float64, 1})
   io_err = Cint[0]
   result = Array(Cdouble, n)
-  uhprod(io_err, Cint[n], Cint[goth], x, vector, result, cutest_lib)
+  uhprod(io_err, Cint[n], Cint[goth], x, vector, result)
   @cutest_error
   return result
 end
 
 function uhprod!(n::Int, goth::Bool, x::Array{Float64, 1}, vector::Array{Float64, 1},
-    result::Array{Float64, 1}, cutest_lib)
+    result::Array{Float64, 1})
   io_err = Cint[0]
-  uhprod(io_err, Cint[n], Cint[goth], x, vector, result, cutest_lib)
+  uhprod(io_err, Cint[n], Cint[goth], x, vector, result)
   @cutest_error
   return
 end
@@ -1024,8 +993,7 @@ function uhprod(nlp::CUTEstModel, goth::Bool, x::Array{Float64, 1},
   io_err = Cint[0]
   n = nlp.meta.nvar
   result = Array(Cdouble, n)
-  uhprod(io_err, Cint[n], Cint[goth], x, vector, result,
-    nlp.cutest_lib)
+  uhprod(io_err, Cint[n], Cint[goth], x, vector, result)
   @cutest_error
   return result
 end
@@ -1034,26 +1002,24 @@ function uhprod!(nlp::CUTEstModel, goth::Bool, x::Array{Float64, 1},
     vector::Array{Float64, 1}, result::Array{Float64, 1})
   io_err = Cint[0]
   n = nlp.meta.nvar
-  uhprod(io_err, Cint[n], Cint[goth], x, vector, result,
-    nlp.cutest_lib)
+  uhprod(io_err, Cint[n], Cint[goth], x, vector, result)
   @cutest_error
   return
 end
 
-function cfn(n::Int, m::Int, x::Array{Float64, 1}, cutest_lib)
+function cfn(n::Int, m::Int, x::Array{Float64, 1})
   io_err = Cint[0]
   f = Cdouble[0]
   c = Array(Cdouble, m)
-  cfn(io_err, Cint[n], Cint[m], x, f, c, cutest_lib)
+  cfn(io_err, Cint[n], Cint[m], x, f, c)
   @cutest_error
   return f[1], c
 end
 
-function cfn!(n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1},
-    cutest_lib)
+function cfn!(n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1})
   io_err = Cint[0]
   f = Cdouble[0]
-  cfn(io_err, Cint[n], Cint[m], x, f, c, cutest_lib)
+  cfn(io_err, Cint[n], Cint[m], x, f, c)
   @cutest_error
   return f[1]
 end
@@ -1064,7 +1030,7 @@ function cfn(nlp::CUTEstModel, x::Array{Float64, 1})
   m = nlp.meta.ncon
   f = Cdouble[0]
   c = Array(Cdouble, m)
-  cfn(io_err, Cint[n], Cint[m], x, f, c, nlp.cutest_lib)
+  cfn(io_err, Cint[n], Cint[m], x, f, c)
   @cutest_error
   return f[1], c
 end
@@ -1074,25 +1040,24 @@ function cfn!(nlp::CUTEstModel, x::Array{Float64, 1}, c::Array{Float64, 1})
   n = nlp.meta.nvar
   m = nlp.meta.ncon
   f = Cdouble[0]
-  cfn(io_err, Cint[n], Cint[m], x, f, c, nlp.cutest_lib)
+  cfn(io_err, Cint[n], Cint[m], x, f, c)
   @cutest_error
   return f[1]
 end
 
-function cofg(n::Int, x::Array{Float64, 1}, grad::Bool, cutest_lib)
+function cofg(n::Int, x::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   g = Array(Cdouble, n)
-  cofg(io_err, Cint[n], x, f, g, Cint[grad], cutest_lib)
+  cofg(io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1], g
 end
 
-function cofg!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, grad::Bool,
-    cutest_lib)
+function cofg!(n::Int, x::Array{Float64, 1}, g::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
-  cofg(io_err, Cint[n], x, f, g, Cint[grad], cutest_lib)
+  cofg(io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1]
 end
@@ -1102,7 +1067,7 @@ function cofg(nlp::CUTEstModel, x::Array{Float64, 1}, grad::Bool)
   n = nlp.meta.nvar
   f = Cdouble[0]
   g = Array(Cdouble, n)
-  cofg(io_err, Cint[n], x, f, g, Cint[grad], nlp.cutest_lib)
+  cofg(io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1], g
 end
@@ -1112,31 +1077,31 @@ function cofg!(nlp::CUTEstModel, x::Array{Float64, 1}, g::Array{Float64, 1},
   io_err = Cint[0]
   n = nlp.meta.nvar
   f = Cdouble[0]
-  cofg(io_err, Cint[n], x, f, g, Cint[grad], nlp.cutest_lib)
+  cofg(io_err, Cint[n], x, f, g, Cint[grad])
   @cutest_error
   return f[1]
 end
 
-function cofsg(n::Int, x::Array{Float64, 1}, lg::Int, grad::Bool, cutest_lib)
+function cofsg(n::Int, x::Array{Float64, 1}, lg::Int, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   nnzg = Cint[0]
   g_val = Array(Cdouble, lg)
   g_var = Array(Cint, lg)
   cofsg(io_err, Cint[n], x, f, nnzg, Cint[lg], g_val, g_var,
-    Cint[grad], cutest_lib)
+    Cint[grad])
   @cutest_error
   return f[1], nnzg[1], g_val, g_var
 end
 
 function cofsg!(n::Int, x::Array{Float64, 1}, lg::Int, g_val::Array{Float64, 1},
-    g_var::Array{Int, 1}, grad::Bool, cutest_lib)
+    g_var::Array{Int, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   nnzg = Cint[0]
   g_var_cp = Array(Cint, lg)
   cofsg(io_err, Cint[n], x, f, nnzg, Cint[lg], g_val, g_var_cp,
-    Cint[grad], cutest_lib)
+    Cint[grad])
   @cutest_error
   for i = 1:lg
     g_var[i] = g_var_cp[i]
@@ -1145,12 +1110,12 @@ function cofsg!(n::Int, x::Array{Float64, 1}, lg::Int, g_val::Array{Float64, 1},
 end
 
 function cofsg!(n::Int, x::Array{Float64, 1}, lg::Int, g_val::Array{Float64, 1},
-    g_var::Array{Cint, 1}, grad::Bool, cutest_lib)
+    g_var::Array{Cint, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   nnzg = Cint[0]
   cofsg(io_err, Cint[n], x, f, nnzg, Cint[lg], g_val, g_var,
-    Cint[grad], cutest_lib)
+    Cint[grad])
   @cutest_error
   return f[1], nnzg[1]
 end
@@ -1163,7 +1128,7 @@ function cofsg(nlp::CUTEstModel, x::Array{Float64, 1}, lg::Int, grad::Bool)
   g_val = Array(Cdouble, lg)
   g_var = Array(Cint, lg)
   cofsg(io_err, Cint[n], x, f, nnzg, Cint[lg], g_val, g_var,
-    Cint[grad], nlp.cutest_lib)
+    Cint[grad])
   @cutest_error
   return f[1], nnzg[1], g_val, g_var
 end
@@ -1176,7 +1141,7 @@ function cofsg!(nlp::CUTEstModel, x::Array{Float64, 1}, lg::Int,
   nnzg = Cint[0]
   g_var_cp = Array(Cint, lg)
   cofsg(io_err, Cint[n], x, f, nnzg, Cint[lg], g_val, g_var_cp,
-    Cint[grad], nlp.cutest_lib)
+    Cint[grad])
   @cutest_error
   for i = 1:lg
     g_var[i] = g_var_cp[i]
@@ -1191,28 +1156,28 @@ function cofsg!(nlp::CUTEstModel, x::Array{Float64, 1}, lg::Int,
   f = Cdouble[0]
   nnzg = Cint[0]
   cofsg(io_err, Cint[n], x, f, nnzg, Cint[lg], g_val, g_var,
-    Cint[grad], nlp.cutest_lib)
+    Cint[grad])
   @cutest_error
   return f[1], nnzg[1]
 end
 
 function ccfg(n::Int, m::Int, x::Array{Float64, 1}, jtrans::Bool, lcjac1::Int,
-    lcjac2::Int, grad::Bool, cutest_lib)
+    lcjac2::Int, grad::Bool)
   io_err = Cint[0]
   c = Array(Cdouble, m)
   cjac = Array(Cdouble, lcjac1, lcjac2)
   ccfg(io_err, Cint[n], Cint[m], x, c, Cint[jtrans], Cint[lcjac1],
-    Cint[lcjac2], cjac, Cint[grad], cutest_lib)
+    Cint[lcjac2], cjac, Cint[grad])
   @cutest_error
   return c, cjac
 end
 
 function ccfg!(n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1},
     jtrans::Bool, lcjac1::Int, lcjac2::Int, cjac::Array{Float64, 2},
-    grad::Bool, cutest_lib)
+    grad::Bool)
   io_err = Cint[0]
   ccfg(io_err, Cint[n], Cint[m], x, c, Cint[jtrans], Cint[lcjac1],
-    Cint[lcjac2], cjac, Cint[grad], cutest_lib)
+    Cint[lcjac2], cjac, Cint[grad])
   @cutest_error
   return
 end
@@ -1225,7 +1190,7 @@ function ccfg(nlp::CUTEstModel, x::Array{Float64, 1}, jtrans::Bool, lcjac1::Int,
   c = Array(Cdouble, m)
   cjac = Array(Cdouble, lcjac1, lcjac2)
   ccfg(io_err, Cint[n], Cint[m], x, c, Cint[jtrans], Cint[lcjac1],
-    Cint[lcjac2], cjac, Cint[grad], nlp.cutest_lib)
+    Cint[lcjac2], cjac, Cint[grad])
   @cutest_error
   return c, cjac
 end
@@ -1237,26 +1202,26 @@ function ccfg!(nlp::CUTEstModel, x::Array{Float64, 1}, c::Array{Float64, 1},
   n = nlp.meta.nvar
   m = nlp.meta.ncon
   ccfg(io_err, Cint[n], Cint[m], x, c, Cint[jtrans], Cint[lcjac1],
-    Cint[lcjac2], cjac, Cint[grad], nlp.cutest_lib)
+    Cint[lcjac2], cjac, Cint[grad])
   @cutest_error
   return
 end
 
 function clfg(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
-    grad::Bool, cutest_lib)
+    grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
   g = Array(Cdouble, n)
-  clfg(io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad], cutest_lib)
+  clfg(io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad])
   @cutest_error
   return f[1], g
 end
 
 function clfg!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
-    g::Array{Float64, 1}, grad::Bool, cutest_lib)
+    g::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   f = Cdouble[0]
-  clfg(io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad], cutest_lib)
+  clfg(io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad])
   @cutest_error
   return f[1]
 end
@@ -1268,8 +1233,7 @@ function clfg(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   m = nlp.meta.ncon
   f = Cdouble[0]
   g = Array(Cdouble, n)
-  clfg(io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad],
-    nlp.cutest_lib)
+  clfg(io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad])
   @cutest_error
   return f[1], g
 end
@@ -1280,29 +1244,28 @@ function clfg!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   n = nlp.meta.nvar
   m = nlp.meta.ncon
   f = Cdouble[0]
-  clfg(io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad],
-    nlp.cutest_lib)
+  clfg(io_err, Cint[n], Cint[m], x, y, f, g, Cint[grad])
   @cutest_error
   return f[1]
 end
 
 function cgr(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
-    grlagf::Bool, jtrans::Bool, lj1::Int, lj2::Int, cutest_lib)
+    grlagf::Bool, jtrans::Bool, lj1::Int, lj2::Int)
   io_err = Cint[0]
   g = Array(Cdouble, n)
   j_val = Array(Cdouble, lj1, lj2)
   cgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
-    Cint[lj1], Cint[lj2], j_val, cutest_lib)
+    Cint[lj1], Cint[lj2], j_val)
   @cutest_error
   return g, j_val
 end
 
 function cgr!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, g::Array{Float64, 1}, jtrans::Bool, lj1::Int, lj2::Int,
-    j_val::Array{Float64, 2}, cutest_lib)
+    j_val::Array{Float64, 2})
   io_err = Cint[0]
   cgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
-    Cint[lj1], Cint[lj2], j_val, cutest_lib)
+    Cint[lj1], Cint[lj2], j_val)
   @cutest_error
   return
 end
@@ -1315,7 +1278,7 @@ function cgr(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   g = Array(Cdouble, n)
   j_val = Array(Cdouble, lj1, lj2)
   cgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
-    Cint[lj1], Cint[lj2], j_val, nlp.cutest_lib)
+    Cint[lj1], Cint[lj2], j_val)
   @cutest_error
   return g, j_val
 end
@@ -1327,33 +1290,33 @@ function cgr!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   n = nlp.meta.nvar
   m = nlp.meta.ncon
   cgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
-    Cint[lj1], Cint[lj2], j_val, nlp.cutest_lib)
+    Cint[lj1], Cint[lj2], j_val)
   @cutest_error
   return
 end
 
 function csgr(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
-    grlagf::Bool, lj::Int, cutest_lib)
+    grlagf::Bool, lj::Int)
   io_err = Cint[0]
   nnzj = Cint[0]
   j_val = Array(Cdouble, lj)
   j_var = Array(Cint, lj)
   j_fun = Array(Cint, lj)
   csgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var, j_fun, cutest_lib)
+    j_val, j_var, j_fun)
   @cutest_error
   return nnzj[1], j_val, j_var, j_fun
 end
 
 function csgr!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, j_val::Array{Float64, 1}, j_var::Array{Int, 1},
-    j_fun::Array{Int, 1}, cutest_lib)
+    j_fun::Array{Int, 1})
   io_err = Cint[0]
   nnzj = Cint[0]
   j_var_cp = Array(Cint, lj)
   j_fun_cp = Array(Cint, lj)
   csgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var_cp, j_fun_cp, cutest_lib)
+    j_val, j_var_cp, j_fun_cp)
   @cutest_error
   for i = 1:lj
     j_var[i] = j_var_cp[i]
@@ -1366,11 +1329,11 @@ end
 
 function csgr!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, j_val::Array{Float64, 1}, j_var::Array{Cint,
-    1}, j_fun::Array{Cint, 1}, cutest_lib)
+    1}, j_fun::Array{Cint, 1})
   io_err = Cint[0]
   nnzj = Cint[0]
   csgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var, j_fun, cutest_lib)
+    j_val, j_var, j_fun)
   @cutest_error
   return nnzj[1]
 end
@@ -1386,7 +1349,7 @@ function csgr(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   j_var = Array(Cint, lj)
   j_fun = Array(Cint, lj)
   csgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var, j_fun, nlp.cutest_lib)
+    j_val, j_var, j_fun)
   @cutest_error
   return nnzj[1], j_val, j_var, j_fun
 end
@@ -1402,7 +1365,7 @@ function csgr!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   j_var_cp = Array(Cint, lj)
   j_fun_cp = Array(Cint, lj)
   csgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var_cp, j_fun_cp, nlp.cutest_lib)
+    j_val, j_var_cp, j_fun_cp)
   @cutest_error
   for i = 1:lj
     j_var[i] = j_var_cp[i]
@@ -1422,13 +1385,12 @@ function csgr!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   nnzj = Cint[0]
   lj = nlp.meta.nnzj + nlp.meta.nvar
   csgr(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var, j_fun, nlp.cutest_lib)
+    j_val, j_var, j_fun)
   @cutest_error
   return nnzj[1]
 end
 
-function ccfsg(n::Int, m::Int, x::Array{Float64, 1}, lj::Int, grad::Bool,
-    cutest_lib)
+function ccfsg(n::Int, m::Int, x::Array{Float64, 1}, lj::Int, grad::Bool)
   io_err = Cint[0]
   c = Array(Cdouble, m)
   nnzj = Cint[0]
@@ -1436,20 +1398,20 @@ function ccfsg(n::Int, m::Int, x::Array{Float64, 1}, lj::Int, grad::Bool,
   j_var = Array(Cint, lj)
   j_fun = Array(Cint, lj)
   ccfsg(io_err, Cint[n], Cint[m], x, c, nnzj, Cint[lj], j_val, j_var,
-    j_fun, Cint[grad], cutest_lib)
+    j_fun, Cint[grad])
   @cutest_error
   return c, nnzj[1], j_val, j_var, j_fun
 end
 
 function ccfsg!(n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1}, lj::Int,
     j_val::Array{Float64, 1}, j_var::Array{Int, 1}, j_fun::Array{Int, 1},
-    grad::Bool, cutest_lib)
+    grad::Bool)
   io_err = Cint[0]
   nnzj = Cint[0]
   j_var_cp = Array(Cint, lj)
   j_fun_cp = Array(Cint, lj)
   ccfsg(io_err, Cint[n], Cint[m], x, c, nnzj, Cint[lj], j_val,
-    j_var_cp, j_fun_cp, Cint[grad], cutest_lib)
+    j_var_cp, j_fun_cp, Cint[grad])
   @cutest_error
   for i = 1:lj
     j_var[i] = j_var_cp[i]
@@ -1462,11 +1424,11 @@ end
 
 function ccfsg!(n::Int, m::Int, x::Array{Float64, 1}, c::Array{Float64, 1}, lj::Int,
     j_val::Array{Float64, 1}, j_var::Array{Cint, 1}, j_fun::Array{Cint,
-    1}, grad::Bool, cutest_lib)
+    1}, grad::Bool)
   io_err = Cint[0]
   nnzj = Cint[0]
   ccfsg(io_err, Cint[n], Cint[m], x, c, nnzj, Cint[lj], j_val, j_var,
-    j_fun, Cint[grad], cutest_lib)
+    j_fun, Cint[grad])
   @cutest_error
   return nnzj[1]
 end
@@ -1482,7 +1444,7 @@ function ccfsg(nlp::CUTEstModel, x::Array{Float64, 1}, grad::Bool)
   j_var = Array(Cint, lj)
   j_fun = Array(Cint, lj)
   ccfsg(io_err, Cint[n], Cint[m], x, c, nnzj, Cint[lj], j_val, j_var,
-    j_fun, Cint[grad], nlp.cutest_lib)
+    j_fun, Cint[grad])
   @cutest_error
   return c, nnzj[1], j_val, j_var, j_fun
 end
@@ -1498,7 +1460,7 @@ function ccfsg!(nlp::CUTEstModel, x::Array{Float64, 1}, c::Array{Float64, 1},
   j_var_cp = Array(Cint, lj)
   j_fun_cp = Array(Cint, lj)
   ccfsg(io_err, Cint[n], Cint[m], x, c, nnzj, Cint[lj], j_val,
-    j_var_cp, j_fun_cp, Cint[grad], nlp.cutest_lib)
+    j_var_cp, j_fun_cp, Cint[grad])
   @cutest_error
   for i = 1:lj
     j_var[i] = j_var_cp[i]
@@ -1518,27 +1480,25 @@ function ccfsg!(nlp::CUTEstModel, x::Array{Float64, 1}, c::Array{Float64, 1},
   nnzj = Cint[0]
   lj = nlp.meta.nnzj
   ccfsg(io_err, Cint[n], Cint[m], x, c, nnzj, Cint[lj], j_val, j_var,
-    j_fun, Cint[grad], nlp.cutest_lib)
+    j_fun, Cint[grad])
   @cutest_error
   return nnzj[1]
 end
 
-function ccifg(n::Int, icon::Int, x::Array{Float64, 1}, grad::Bool, cutest_lib)
+function ccifg(n::Int, icon::Int, x::Array{Float64, 1}, grad::Bool)
   io_err = Cint[0]
   ci = Cdouble[0]
   gci = Array(Cdouble, n)
-  ccifg(io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad],
-    cutest_lib)
+  ccifg(io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad])
   @cutest_error
   return ci[1], gci
 end
 
 function ccifg!(n::Int, icon::Int, x::Array{Float64, 1}, gci::Array{Float64, 1},
-    grad::Bool, cutest_lib)
+    grad::Bool)
   io_err = Cint[0]
   ci = Cdouble[0]
-  ccifg(io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad],
-    cutest_lib)
+  ccifg(io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad])
   @cutest_error
   return ci[1]
 end
@@ -1548,8 +1508,7 @@ function ccifg(nlp::CUTEstModel, icon::Int, x::Array{Float64, 1}, grad::Bool)
   n = nlp.meta.nvar
   ci = Cdouble[0]
   gci = Array(Cdouble, n)
-  ccifg(io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad],
-    nlp.cutest_lib)
+  ccifg(io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad])
   @cutest_error
   return ci[1], gci
 end
@@ -1559,34 +1518,31 @@ function ccifg!(nlp::CUTEstModel, icon::Int, x::Array{Float64, 1},
   io_err = Cint[0]
   n = nlp.meta.nvar
   ci = Cdouble[0]
-  ccifg(io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad],
-    nlp.cutest_lib)
+  ccifg(io_err, Cint[n], Cint[icon], x, ci, gci, Cint[grad])
   @cutest_error
   return ci[1]
 end
 
-function ccifsg(n::Int, icon::Int, x::Array{Float64, 1}, lgci::Int, grad::Bool,
-    cutest_lib)
+function ccifsg(n::Int, icon::Int, x::Array{Float64, 1}, lgci::Int, grad::Bool)
   io_err = Cint[0]
   ci = Cdouble[0]
   nnzgci = Cint[0]
   gci_val = Array(Cdouble, lgci)
   gci_var = Array(Cint, lgci)
   ccifsg(io_err, Cint[n], Cint[icon], x, ci, nnzgci, Cint[lgci],
-    gci_val, gci_var, Cint[grad], cutest_lib)
+    gci_val, gci_var, Cint[grad])
   @cutest_error
   return ci[1], nnzgci[1], gci_val, gci_var
 end
 
 function ccifsg!(n::Int, icon::Int, x::Array{Float64, 1}, lgci::Int,
-    gci_val::Array{Float64, 1}, gci_var::Array{Int, 1}, grad::Bool,
-    cutest_lib)
+    gci_val::Array{Float64, 1}, gci_var::Array{Int, 1}, grad::Bool)
   io_err = Cint[0]
   ci = Cdouble[0]
   nnzgci = Cint[0]
   gci_var_cp = Array(Cint, lgci)
   ccifsg(io_err, Cint[n], Cint[icon], x, ci, nnzgci, Cint[lgci],
-    gci_val, gci_var_cp, Cint[grad], cutest_lib)
+    gci_val, gci_var_cp, Cint[grad])
   @cutest_error
   for i = 1:lgci
     gci_var[i] = gci_var_cp[i]
@@ -1595,13 +1551,12 @@ function ccifsg!(n::Int, icon::Int, x::Array{Float64, 1}, lgci::Int,
 end
 
 function ccifsg!(n::Int, icon::Int, x::Array{Float64, 1}, lgci::Int,
-    gci_val::Array{Float64, 1}, gci_var::Array{Cint, 1}, grad::Bool,
-    cutest_lib)
+    gci_val::Array{Float64, 1}, gci_var::Array{Cint, 1}, grad::Bool)
   io_err = Cint[0]
   ci = Cdouble[0]
   nnzgci = Cint[0]
   ccifsg(io_err, Cint[n], Cint[icon], x, ci, nnzgci, Cint[lgci],
-    gci_val, gci_var, Cint[grad], cutest_lib)
+    gci_val, gci_var, Cint[grad])
   @cutest_error
   return ci[1], nnzgci[1]
 end
@@ -1615,7 +1570,7 @@ function ccifsg(nlp::CUTEstModel, icon::Int, x::Array{Float64, 1}, lgci::Int,
   gci_val = Array(Cdouble, lgci)
   gci_var = Array(Cint, lgci)
   ccifsg(io_err, Cint[n], Cint[icon], x, ci, nnzgci, Cint[lgci],
-    gci_val, gci_var, Cint[grad], nlp.cutest_lib)
+    gci_val, gci_var, Cint[grad])
   @cutest_error
   return ci[1], nnzgci[1], gci_val, gci_var
 end
@@ -1628,7 +1583,7 @@ function ccifsg!(nlp::CUTEstModel, icon::Int, x::Array{Float64, 1}, lgci::Int,
   nnzgci = Cint[0]
   gci_var_cp = Array(Cint, lgci)
   ccifsg(io_err, Cint[n], Cint[icon], x, ci, nnzgci, Cint[lgci],
-    gci_val, gci_var_cp, Cint[grad], nlp.cutest_lib)
+    gci_val, gci_var_cp, Cint[grad])
   @cutest_error
   for i = 1:lgci
     gci_var[i] = gci_var_cp[i]
@@ -1643,30 +1598,29 @@ function ccifsg!(nlp::CUTEstModel, icon::Int, x::Array{Float64, 1}, lgci::Int,
   ci = Cdouble[0]
   nnzgci = Cint[0]
   ccifsg(io_err, Cint[n], Cint[icon], x, ci, nnzgci, Cint[lgci],
-    gci_val, gci_var, Cint[grad], nlp.cutest_lib)
+    gci_val, gci_var, Cint[grad])
   @cutest_error
   return ci[1], nnzgci[1]
 end
 
 function cgrdh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
-    grlagf::Bool, jtrans::Bool, lj1::Int, lj2::Int, lh1::Int, cutest_lib)
+    grlagf::Bool, jtrans::Bool, lj1::Int, lj2::Int, lh1::Int)
   io_err = Cint[0]
   g = Array(Cdouble, n)
   j_val = Array(Cdouble, lj1, lj2)
   h_val = Array(Cdouble, lh1, n)
   cgrdh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
-    Cint[lj1], Cint[lj2], j_val, Cint[lh1], h_val, cutest_lib)
+    Cint[lj1], Cint[lj2], j_val, Cint[lh1], h_val)
   @cutest_error
   return g, j_val, h_val
 end
 
 function cgrdh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, g::Array{Float64, 1}, jtrans::Bool, lj1::Int, lj2::Int,
-    j_val::Array{Float64, 2}, lh1::Int, h_val::Array{Float64, 2},
-    cutest_lib)
+    j_val::Array{Float64, 2}, lh1::Int, h_val::Array{Float64, 2})
   io_err = Cint[0]
   cgrdh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
-    Cint[lj1], Cint[lj2], j_val, Cint[lh1], h_val, cutest_lib)
+    Cint[lj1], Cint[lj2], j_val, Cint[lh1], h_val)
   @cutest_error
   return
 end
@@ -1680,7 +1634,7 @@ function cgrdh(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   j_val = Array(Cdouble, lj1, lj2)
   h_val = Array(Cdouble, lh1, n)
   cgrdh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
-    Cint[lj1], Cint[lj2], j_val, Cint[lh1], h_val, nlp.cutest_lib)
+    Cint[lj1], Cint[lj2], j_val, Cint[lh1], h_val)
   @cutest_error
   return g, j_val, h_val
 end
@@ -1692,24 +1646,23 @@ function cgrdh!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   n = nlp.meta.nvar
   m = nlp.meta.ncon
   cgrdh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], g, Cint[jtrans],
-    Cint[lj1], Cint[lj2], j_val, Cint[lh1], h_val, nlp.cutest_lib)
+    Cint[lj1], Cint[lj2], j_val, Cint[lh1], h_val)
   @cutest_error
   return
 end
 
-function cdh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int,
-    cutest_lib)
+function cdh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int)
   io_err = Cint[0]
   h_val = Array(Cdouble, lh1, n)
-  cdh(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val, cutest_lib)
+  cdh(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
   @cutest_error
   return h_val
 end
 
 function cdh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh1::Int,
-    h_val::Array{Float64, 2}, cutest_lib)
+    h_val::Array{Float64, 2})
   io_err = Cint[0]
-  cdh(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val, cutest_lib)
+  cdh(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
   @cutest_error
   return
 end
@@ -1720,8 +1673,7 @@ function cdh(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   n = nlp.meta.nvar
   m = nlp.meta.ncon
   h_val = Array(Cdouble, lh1, n)
-  cdh(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val,
-    nlp.cutest_lib)
+  cdh(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
   @cutest_error
   return h_val
 end
@@ -1731,34 +1683,31 @@ function cdh!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   io_err = Cint[0]
   n = nlp.meta.nvar
   m = nlp.meta.ncon
-  cdh(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val,
-    nlp.cutest_lib)
+  cdh(io_err, Cint[n], Cint[m], x, y, Cint[lh1], h_val)
   @cutest_error
   return
 end
 
-function csh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int,
-    cutest_lib)
+function csh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int)
   io_err = Cint[0]
   nnzh = Cint[0]
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
   csh(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
-    h_col, cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
 end
 
 function csh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int,
-    h_val::Array{Float64, 1}, h_row::Array{Int, 1}, h_col::Array{Int, 1},
-    cutest_lib)
+    h_val::Array{Float64, 1}, h_row::Array{Int, 1}, h_col::Array{Int, 1})
   io_err = Cint[0]
   nnzh = Cint[0]
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
   csh(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row_cp,
-    h_col_cp, cutest_lib)
+    h_col_cp)
   @cutest_error
   for i = 1:lh
     h_row[i] = h_row_cp[i]
@@ -1771,11 +1720,11 @@ end
 
 function csh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int,
     h_val::Array{Float64, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
-    1}, cutest_lib)
+    1})
   io_err = Cint[0]
   nnzh = Cint[0]
   csh(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
-    h_col, cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1]
 end
@@ -1790,7 +1739,7 @@ function csh(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1})
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
   csh(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
-    h_col, nlp.cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
 end
@@ -1805,7 +1754,7 @@ function csh!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
   csh(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row_cp,
-    h_col_cp, nlp.cutest_lib)
+    h_col_cp)
   @cutest_error
   for i = 1:lh
     h_row[i] = h_row_cp[i]
@@ -1825,33 +1774,31 @@ function csh!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   nnzh = Cint[0]
   lh = nlp.meta.nnzh
   csh(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
-    h_col, nlp.cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1]
 end
 
-function cshc(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int,
-    cutest_lib)
+function cshc(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int)
   io_err = Cint[0]
   nnzh = Cint[0]
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
   cshc(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
-    h_col, cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
 end
 
 function cshc!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int,
-    h_val::Array{Float64, 1}, h_row::Array{Int, 1}, h_col::Array{Int, 1},
-    cutest_lib)
+    h_val::Array{Float64, 1}, h_row::Array{Int, 1}, h_col::Array{Int, 1})
   io_err = Cint[0]
   nnzh = Cint[0]
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
   cshc(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val,
-    h_row_cp, h_col_cp, cutest_lib)
+    h_row_cp, h_col_cp)
   @cutest_error
   for i = 1:lh
     h_row[i] = h_row_cp[i]
@@ -1864,11 +1811,11 @@ end
 
 function cshc!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1}, lh::Int,
     h_val::Array{Float64, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
-    1}, cutest_lib)
+    1})
   io_err = Cint[0]
   nnzh = Cint[0]
   cshc(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
-    h_col, cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1]
 end
@@ -1883,7 +1830,7 @@ function cshc(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1})
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
   cshc(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
-    h_col, nlp.cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
 end
@@ -1898,7 +1845,7 @@ function cshc!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
   cshc(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val,
-    h_row_cp, h_col_cp, nlp.cutest_lib)
+    h_row_cp, h_col_cp)
   @cutest_error
   for i = 1:lh
     h_row[i] = h_row_cp[i]
@@ -1918,13 +1865,13 @@ function cshc!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   nnzh = Cint[0]
   lh = nlp.meta.nnzh
   cshc(io_err, Cint[n], Cint[m], x, y, nnzh, Cint[lh], h_val, h_row,
-    h_col, nlp.cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1]
 end
 
 function ceh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
-    lhe_ptr::Int, lhe_row::Int, lhe_val::Int, byrows::Bool, cutest_lib)
+    lhe_ptr::Int, lhe_row::Int, lhe_val::Int, byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
   he_row_ptr = Array(Cint, lhe_ptr)
@@ -1933,7 +1880,7 @@ function ceh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
   he_val = Array(Cdouble, lhe_val)
   ceh(io_err, Cint[n], Cint[m], x, y, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
-    Cint[byrows], cutest_lib)
+    Cint[byrows])
   @cutest_error
   return ne[1], he_row_ptr, he_val_ptr, he_row, he_val
 end
@@ -1941,7 +1888,7 @@ end
 function ceh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     lhe_ptr::Int, he_row_ptr::Array{Int, 1}, he_val_ptr::Array{Int, 1},
     lhe_row::Int, he_row::Array{Int, 1}, lhe_val::Int,
-    he_val::Array{Float64, 1}, byrows::Bool, cutest_lib)
+    he_val::Array{Float64, 1}, byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
   he_row_ptr_cp = Array(Cint, lhe_ptr)
@@ -1949,7 +1896,7 @@ function ceh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
   he_row_cp = Array(Cint, lhe_row)
   ceh(io_err, Cint[n], Cint[m], x, y, ne, Cint[lhe_ptr],
     he_row_ptr_cp, he_val_ptr_cp, Cint[lhe_row], he_row_cp, Cint[lhe_val],
-    he_val, Cint[byrows], cutest_lib)
+    he_val, Cint[byrows])
   @cutest_error
   for i = 1:lhe_ptr
     he_row_ptr[i] = he_row_ptr_cp[i]
@@ -1966,12 +1913,12 @@ end
 function ceh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     lhe_ptr::Int, he_row_ptr::Array{Cint, 1}, he_val_ptr::Array{Cint, 1},
     lhe_row::Int, he_row::Array{Cint, 1}, lhe_val::Int,
-    he_val::Array{Float64, 1}, byrows::Bool, cutest_lib)
+    he_val::Array{Float64, 1}, byrows::Bool)
   io_err = Cint[0]
   ne = Cint[0]
   ceh(io_err, Cint[n], Cint[m], x, y, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
-    Cint[byrows], cutest_lib)
+    Cint[byrows])
   @cutest_error
   return ne[1]
 end
@@ -1988,7 +1935,7 @@ function ceh(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   he_val = Array(Cdouble, lhe_val)
   ceh(io_err, Cint[n], Cint[m], x, y, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
-    Cint[byrows], nlp.cutest_lib)
+    Cint[byrows])
   @cutest_error
   return ne[1], he_row_ptr, he_val_ptr, he_row, he_val
 end
@@ -2006,7 +1953,7 @@ function ceh!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   he_row_cp = Array(Cint, lhe_row)
   ceh(io_err, Cint[n], Cint[m], x, y, ne, Cint[lhe_ptr],
     he_row_ptr_cp, he_val_ptr_cp, Cint[lhe_row], he_row_cp, Cint[lhe_val],
-    he_val, Cint[byrows], nlp.cutest_lib)
+    he_val, Cint[byrows])
   @cutest_error
   for i = 1:lhe_ptr
     he_row_ptr[i] = he_row_ptr_cp[i]
@@ -2030,23 +1977,23 @@ function ceh!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   ne = Cint[0]
   ceh(io_err, Cint[n], Cint[m], x, y, ne, Cint[lhe_ptr], he_row_ptr,
     he_val_ptr, Cint[lhe_row], he_row, Cint[lhe_val], he_val,
-    Cint[byrows], nlp.cutest_lib)
+    Cint[byrows])
   @cutest_error
   return ne[1]
 end
 
-function cidh(n::Int, x::Array{Float64, 1}, iprob::Int, lh1::Int, cutest_lib)
+function cidh(n::Int, x::Array{Float64, 1}, iprob::Int, lh1::Int)
   io_err = Cint[0]
   h = Array(Cdouble, lh1, n)
-  cidh(io_err, Cint[n], x, Cint[iprob], Cint[lh1], h, cutest_lib)
+  cidh(io_err, Cint[n], x, Cint[iprob], Cint[lh1], h)
   @cutest_error
   return h
 end
 
 function cidh!(n::Int, x::Array{Float64, 1}, iprob::Int, lh1::Int, h::Array{Float64,
-    2}, cutest_lib)
+    2})
   io_err = Cint[0]
-  cidh(io_err, Cint[n], x, Cint[iprob], Cint[lh1], h, cutest_lib)
+  cidh(io_err, Cint[n], x, Cint[iprob], Cint[lh1], h)
   @cutest_error
   return
 end
@@ -2055,7 +2002,7 @@ function cidh(nlp::CUTEstModel, x::Array{Float64, 1}, iprob::Int, lh1::Int)
   io_err = Cint[0]
   n = nlp.meta.nvar
   h = Array(Cdouble, lh1, n)
-  cidh(io_err, Cint[n], x, Cint[iprob], Cint[lh1], h, nlp.cutest_lib)
+  cidh(io_err, Cint[n], x, Cint[iprob], Cint[lh1], h)
   @cutest_error
   return h
 end
@@ -2064,32 +2011,31 @@ function cidh!(nlp::CUTEstModel, x::Array{Float64, 1}, iprob::Int, lh1::Int,
     h::Array{Float64, 2})
   io_err = Cint[0]
   n = nlp.meta.nvar
-  cidh(io_err, Cint[n], x, Cint[iprob], Cint[lh1], h, nlp.cutest_lib)
+  cidh(io_err, Cint[n], x, Cint[iprob], Cint[lh1], h)
   @cutest_error
   return
 end
 
-function cish(n::Int, x::Array{Float64, 1}, iprob::Int, lh::Int, cutest_lib)
+function cish(n::Int, x::Array{Float64, 1}, iprob::Int, lh::Int)
   io_err = Cint[0]
   nnzh = Cint[0]
   h_val = Array(Cdouble, lh)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
   cish(io_err, Cint[n], x, Cint[iprob], nnzh, Cint[lh], h_val, h_row,
-    h_col, cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
 end
 
 function cish!(n::Int, x::Array{Float64, 1}, iprob::Int, lh::Int,
-    h_val::Array{Float64, 1}, h_row::Array{Int, 1}, h_col::Array{Int, 1},
-    cutest_lib)
+    h_val::Array{Float64, 1}, h_row::Array{Int, 1}, h_col::Array{Int, 1})
   io_err = Cint[0]
   nnzh = Cint[0]
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
   cish(io_err, Cint[n], x, Cint[iprob], nnzh, Cint[lh], h_val,
-    h_row_cp, h_col_cp, cutest_lib)
+    h_row_cp, h_col_cp)
   @cutest_error
   for i = 1:lh
     h_row[i] = h_row_cp[i]
@@ -2102,11 +2048,11 @@ end
 
 function cish!(n::Int, x::Array{Float64, 1}, iprob::Int, lh::Int,
     h_val::Array{Float64, 1}, h_row::Array{Cint, 1}, h_col::Array{Cint,
-    1}, cutest_lib)
+    1})
   io_err = Cint[0]
   nnzh = Cint[0]
   cish(io_err, Cint[n], x, Cint[iprob], nnzh, Cint[lh], h_val, h_row,
-    h_col, cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1]
 end
@@ -2120,7 +2066,7 @@ function cish(nlp::CUTEstModel, x::Array{Float64, 1}, iprob::Int)
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
   cish(io_err, Cint[n], x, Cint[iprob], nnzh, Cint[lh], h_val, h_row,
-    h_col, nlp.cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1], h_val, h_row, h_col
 end
@@ -2134,7 +2080,7 @@ function cish!(nlp::CUTEstModel, x::Array{Float64, 1}, iprob::Int,
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
   cish(io_err, Cint[n], x, Cint[iprob], nnzh, Cint[lh], h_val,
-    h_row_cp, h_col_cp, nlp.cutest_lib)
+    h_row_cp, h_col_cp)
   @cutest_error
   for i = 1:lh
     h_row[i] = h_row_cp[i]
@@ -2153,13 +2099,13 @@ function cish!(nlp::CUTEstModel, x::Array{Float64, 1}, iprob::Int,
   nnzh = Cint[0]
   lh = nlp.meta.nnzh
   cish(io_err, Cint[n], x, Cint[iprob], nnzh, Cint[lh], h_val, h_row,
-    h_col, nlp.cutest_lib)
+    h_col)
   @cutest_error
   return nnzh[1]
 end
 
 function csgrsh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
-    grlagf::Bool, lj::Int, lh::Int, cutest_lib)
+    grlagf::Bool, lj::Int, lh::Int)
   io_err = Cint[0]
   nnzj = Cint[0]
   j_val = Array(Cdouble, lj)
@@ -2170,7 +2116,7 @@ function csgrsh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
   csgrsh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var, j_fun, nnzh, Cint[lh], h_val, h_row, h_col, cutest_lib)
+    j_val, j_var, j_fun, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzj[1], j_val, j_var, j_fun, nnzh[1], h_val, h_row, h_col
 end
@@ -2178,7 +2124,7 @@ end
 function csgrsh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, j_val::Array{Float64, 1}, j_var::Array{Int, 1},
     j_fun::Array{Int, 1}, lh::Int, h_val::Array{Float64, 1},
-    h_row::Array{Int, 1}, h_col::Array{Int, 1}, cutest_lib)
+    h_row::Array{Int, 1}, h_col::Array{Int, 1})
   io_err = Cint[0]
   nnzj = Cint[0]
   j_var_cp = Array(Cint, lj)
@@ -2187,8 +2133,7 @@ function csgrsh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
   csgrsh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var_cp, j_fun_cp, nnzh, Cint[lh], h_val, h_row_cp, h_col_cp,
-    cutest_lib)
+    j_val, j_var_cp, j_fun_cp, nnzh, Cint[lh], h_val, h_row_cp, h_col_cp)
   @cutest_error
   for i = 1:lj
     j_var[i] = j_var_cp[i]
@@ -2208,12 +2153,12 @@ end
 function csgrsh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, j_val::Array{Float64, 1}, j_var::Array{Cint,
     1}, j_fun::Array{Cint, 1}, lh::Int, h_val::Array{Float64, 1},
-    h_row::Array{Cint, 1}, h_col::Array{Cint, 1}, cutest_lib)
+    h_row::Array{Cint, 1}, h_col::Array{Cint, 1})
   io_err = Cint[0]
   nnzj = Cint[0]
   nnzh = Cint[0]
   csgrsh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var, j_fun, nnzh, Cint[lh], h_val, h_row, h_col, cutest_lib)
+    j_val, j_var, j_fun, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzj[1], nnzh[1]
 end
@@ -2234,8 +2179,7 @@ function csgrsh(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   h_row = Array(Cint, lh)
   h_col = Array(Cint, lh)
   csgrsh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var, j_fun, nnzh, Cint[lh], h_val, h_row, h_col,
-    nlp.cutest_lib)
+    j_val, j_var, j_fun, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzj[1], j_val, j_var, j_fun, nnzh[1], h_val, h_row, h_col
 end
@@ -2256,8 +2200,7 @@ function csgrsh!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   h_row_cp = Array(Cint, lh)
   h_col_cp = Array(Cint, lh)
   csgrsh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var_cp, j_fun_cp, nnzh, Cint[lh], h_val, h_row_cp, h_col_cp,
-    nlp.cutest_lib)
+    j_val, j_var_cp, j_fun_cp, nnzh, Cint[lh], h_val, h_row_cp, h_col_cp)
   @cutest_error
   for i = 1:lj
     j_var[i] = j_var_cp[i]
@@ -2286,15 +2229,14 @@ function csgrsh!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   nnzh = Cint[0]
   lh = nlp.meta.nnzh
   csgrsh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
-    j_val, j_var, j_fun, nnzh, Cint[lh], h_val, h_row, h_col,
-    nlp.cutest_lib)
+    j_val, j_var, j_fun, nnzh, Cint[lh], h_val, h_row, h_col)
   @cutest_error
   return nnzj[1], nnzh[1]
 end
 
 function csgreh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, lhe_ptr::Int, lhe_row::Int, lhe_val::Int,
-    byrows::Bool, cutest_lib)
+    byrows::Bool)
   io_err = Cint[0]
   nnzj = Cint[0]
   j_val = Array(Cdouble, lj)
@@ -2307,8 +2249,7 @@ function csgreh(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
   he_val = Array(Cdouble, lhe_val)
   csgreh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var, j_fun, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
-    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows],
-    cutest_lib)
+    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
   return nnzj[1], j_val, j_var, j_fun, ne[1], he_row_ptr, he_val_ptr, he_row, he_val
 end
@@ -2317,7 +2258,7 @@ function csgreh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, j_val::Array{Float64, 1}, j_var::Array{Int, 1},
     j_fun::Array{Int, 1}, lhe_ptr::Int, he_row_ptr::Array{Int, 1},
     he_val_ptr::Array{Int, 1}, lhe_row::Int, he_row::Array{Int, 1},
-    lhe_val::Int, he_val::Array{Float64, 1}, byrows::Bool, cutest_lib)
+    lhe_val::Int, he_val::Array{Float64, 1}, byrows::Bool)
   io_err = Cint[0]
   nnzj = Cint[0]
   j_var_cp = Array(Cint, lj)
@@ -2329,7 +2270,7 @@ function csgreh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
   csgreh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var_cp, j_fun_cp, ne, Cint[lhe_ptr], he_row_ptr_cp,
     he_val_ptr_cp, Cint[lhe_row], he_row_cp, Cint[lhe_val], he_val,
-    Cint[byrows], cutest_lib)
+    Cint[byrows])
   @cutest_error
   for i = 1:lj
     j_var[i] = j_var_cp[i]
@@ -2353,14 +2294,13 @@ function csgreh!(n::Int, m::Int, x::Array{Float64, 1}, y::Array{Float64, 1},
     grlagf::Bool, lj::Int, j_val::Array{Float64, 1}, j_var::Array{Cint,
     1}, j_fun::Array{Cint, 1}, lhe_ptr::Int, he_row_ptr::Array{Cint, 1},
     he_val_ptr::Array{Cint, 1}, lhe_row::Int, he_row::Array{Cint, 1},
-    lhe_val::Int, he_val::Array{Float64, 1}, byrows::Bool, cutest_lib)
+    lhe_val::Int, he_val::Array{Float64, 1}, byrows::Bool)
   io_err = Cint[0]
   nnzj = Cint[0]
   ne = Cint[0]
   csgreh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var, j_fun, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
-    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows],
-    cutest_lib)
+    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
   return nnzj[1], ne[1]
 end
@@ -2382,8 +2322,7 @@ function csgreh(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   he_val = Array(Cdouble, lhe_val)
   csgreh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var, j_fun, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
-    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows],
-    nlp.cutest_lib)
+    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
   return nnzj[1], j_val, j_var, j_fun, ne[1], he_row_ptr, he_val_ptr, he_row, he_val
 end
@@ -2407,7 +2346,7 @@ function csgreh!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   csgreh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var_cp, j_fun_cp, ne, Cint[lhe_ptr], he_row_ptr_cp,
     he_val_ptr_cp, Cint[lhe_row], he_row_cp, Cint[lhe_val], he_val,
-    Cint[byrows], nlp.cutest_lib)
+    Cint[byrows])
   @cutest_error
   for i = 1:lj
     j_var[i] = j_var_cp[i]
@@ -2440,27 +2379,24 @@ function csgreh!(nlp::CUTEstModel, x::Array{Float64, 1}, y::Array{Float64, 1},
   ne = Cint[0]
   csgreh(io_err, Cint[n], Cint[m], x, y, Cint[grlagf], nnzj, Cint[lj],
     j_val, j_var, j_fun, ne, Cint[lhe_ptr], he_row_ptr, he_val_ptr,
-    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows],
-    nlp.cutest_lib)
+    Cint[lhe_row], he_row, Cint[lhe_val], he_val, Cint[byrows])
   @cutest_error
   return nnzj[1], ne[1]
 end
 
 function chprod(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
-    1}, vector::Array{Float64, 1}, cutest_lib)
+    1}, vector::Array{Float64, 1})
   io_err = Cint[0]
   result = Array(Cdouble, n)
-  chprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result,
-    cutest_lib)
+  chprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return result
 end
 
 function chprod!(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
-    1}, vector::Array{Float64, 1}, result::Array{Float64, 1}, cutest_lib)
+    1}, vector::Array{Float64, 1}, result::Array{Float64, 1})
   io_err = Cint[0]
-  chprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result,
-    cutest_lib)
+  chprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return
 end
@@ -2471,8 +2407,7 @@ function chprod(nlp::CUTEstModel, goth::Bool, x::Array{Float64, 1}, y::Array{Flo
   n = nlp.meta.nvar
   m = nlp.meta.ncon
   result = Array(Cdouble, n)
-  chprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result,
-    nlp.cutest_lib)
+  chprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return result
 end
@@ -2482,27 +2417,24 @@ function chprod!(nlp::CUTEstModel, goth::Bool, x::Array{Float64, 1}, y::Array{Fl
   io_err = Cint[0]
   n = nlp.meta.nvar
   m = nlp.meta.ncon
-  chprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result,
-    nlp.cutest_lib)
+  chprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return
 end
 
 function chcprod(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
-    1}, vector::Array{Float64, 1}, cutest_lib)
+    1}, vector::Array{Float64, 1})
   io_err = Cint[0]
   result = Array(Cdouble, n)
-  chcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result,
-    cutest_lib)
+  chcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return result
 end
 
 function chcprod!(n::Int, m::Int, goth::Bool, x::Array{Float64, 1}, y::Array{Float64,
-    1}, vector::Array{Float64, 1}, result::Array{Float64, 1}, cutest_lib)
+    1}, vector::Array{Float64, 1}, result::Array{Float64, 1})
   io_err = Cint[0]
-  chcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result,
-    cutest_lib)
+  chcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return
 end
@@ -2513,8 +2445,7 @@ function chcprod(nlp::CUTEstModel, goth::Bool, x::Array{Float64, 1}, y::Array{Fl
   n = nlp.meta.nvar
   m = nlp.meta.ncon
   result = Array(Cdouble, n)
-  chcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result,
-    nlp.cutest_lib)
+  chcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return result
 end
@@ -2524,28 +2455,27 @@ function chcprod!(nlp::CUTEstModel, goth::Bool, x::Array{Float64, 1}, y::Array{F
   io_err = Cint[0]
   n = nlp.meta.nvar
   m = nlp.meta.ncon
-  chcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result,
-    nlp.cutest_lib)
+  chcprod(io_err, Cint[n], Cint[m], Cint[goth], x, y, vector, result)
   @cutest_error
   return
 end
 
 function cjprod(n::Int, m::Int, gotj::Bool, jtrans::Bool, x::Array{Float64, 1},
-    vector::Array{Float64, 1}, lvector::Int, lresult::Int, cutest_lib)
+    vector::Array{Float64, 1}, lvector::Int, lresult::Int)
   io_err = Cint[0]
   result = Array(Cdouble, lresult)
   cjprod(io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
-    vector, Cint[lvector], result, Cint[lresult], cutest_lib)
+    vector, Cint[lvector], result, Cint[lresult])
   @cutest_error
   return result
 end
 
 function cjprod!(n::Int, m::Int, gotj::Bool, jtrans::Bool, x::Array{Float64, 1},
     vector::Array{Float64, 1}, lvector::Int, result::Array{Float64, 1},
-    lresult::Int, cutest_lib)
+    lresult::Int)
   io_err = Cint[0]
   cjprod(io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
-    vector, Cint[lvector], result, Cint[lresult], cutest_lib)
+    vector, Cint[lvector], result, Cint[lresult])
   @cutest_error
   return
 end
@@ -2557,7 +2487,7 @@ function cjprod(nlp::CUTEstModel, gotj::Bool, jtrans::Bool, x::Array{Float64, 1}
   m = nlp.meta.ncon
   result = Array(Cdouble, lresult)
   cjprod(io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
-    vector, Cint[lvector], result, Cint[lresult], nlp.cutest_lib)
+    vector, Cint[lvector], result, Cint[lresult])
   @cutest_error
   return result
 end
@@ -2569,21 +2499,19 @@ function cjprod!(nlp::CUTEstModel, gotj::Bool, jtrans::Bool, x::Array{Float64, 1
   n = nlp.meta.nvar
   m = nlp.meta.ncon
   cjprod(io_err, Cint[n], Cint[m], Cint[gotj], Cint[jtrans], x,
-    vector, Cint[lvector], result, Cint[lresult], nlp.cutest_lib)
+    vector, Cint[lvector], result, Cint[lresult])
   @cutest_error
   return
 end
 
-function uterminate(cutest_lib)
-  io_err = Cint[0]
-  uterminate(io_err, cutest_lib)
+function uterminate()  io_err = Cint[0]
+  uterminate(io_err)
   @cutest_error
   return
 end
 
-function cterminate(cutest_lib)
-  io_err = Cint[0]
-  cterminate(io_err, cutest_lib)
+function cterminate()  io_err = Cint[0]
+  cterminate(io_err)
   @cutest_error
   return
 end

--- a/test/finalize_test.jl
+++ b/test/finalize_test.jl
@@ -1,3 +1,4 @@
+println("Finalizing")
 cutest_finalize(nlp);
 
 # Return to initial directory.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,46 @@
-problem = "HS32"
-include("hs32.jl")
-include("build_test.jl")
-include("test_core.jl")
-include("test_specialized.jl")
-include("test_julia.jl")
-include("finalize_test.jl")
+for problem in ["HS32", "HS4"]
+  global problem
+  include("$(lowercase(problem)).jl")
+  include("build_test.jl")
+  include("test_core.jl")
+  include("test_specialized.jl")
+  include("test_julia.jl")
+  include("finalize_test.jl")
+end
+
+problems = readdir(get(ENV, "MASTSIF", "") )
+
+for p in problems
+  if !contains(p, "SIF")
+    continue
+  end
+  p = p[1:end-4]
+
+  nlp = CUTEstModel(p)
+  x0 = nlp.meta.x0
+  nvar, ncon = nlp.meta.nvar, nlp.meta.ncon
+
+  println("$p: julia interface: f(x₀) = $(obj(nlp, x0))")
+
+  io_err = Cint[0]
+  fval = [0.0]
+  if ncon > 0
+    cx = zeros(ncon)
+    cfn(io_err, Cint[nvar], Cint[ncon], x0, fval, cx)
+  else
+    ufn(io_err, Cint[nvar], x0, fval)
+  end
+  println("$p: core interface: f(x₀) = $(fval[1])")
+
+  if ncon > 0
+    cx = zeros(ncon)
+    println("$p: specialized interface: f(x₀) = $(cfn(nvar, ncon, x0)[1])")
+    println("$p: specialized interface: f(x₀) = $(cfn!(nvar, ncon, x0, cx)[1])")
+    println("$p: specialized interface: f(x₀) = $(cfn(nlp, x0)[1])")
+    println("$p: specialized interface: f(x₀) = $(cfn!(nlp, x0, cx)[1])")
+  else
+    println("$p: specialized interface: f(x₀) = $(ufn(nvar, x0))")
+    println("$p: specialized interface: f(x₀) = $(ufn(nlp, x0))")
+  end
+  cutest_finalize(nlp)
+end

--- a/test/runtests_unc.jl
+++ b/test/runtests_unc.jl
@@ -1,7 +1,0 @@
-problem = "HS4"
-include("hs4.jl")
-include("build_test.jl")
-include("test_core.jl")
-include("test_specialized.jl")
-include("test_julia.jl")
-include("finalize_test.jl")

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -31,15 +31,15 @@ Hrow = Array(Cint, nlp.meta.nnzh)
 Hcol = Array(Cint, nlp.meta.nnzh)
 
 if (ncon[1] > 0)
-  cfn(st, nvar, ncon, x0, fx, cx, nlp.cutest_lib)
+  cfn(st, nvar, ncon, x0, fx, cx)
   @test_approx_eq_eps fx[1] f(x0) 1e-8
   @test_approx_eq_eps cx c(x0) 1e-8
 
-  cofg(st, nvar, x0, fx, gx, True, nlp.cutest_lib)
+  cofg(st, nvar, x0, fx, gx, True)
   @test_approx_eq_eps fx[1] f(x0) 1e-8
   @test_approx_eq_eps gx g(x0) 1e-8
 
-  cofsg(st, nvar, x0, fx, nnzg, nvar, gval, gvar, True, nlp.cutest_lib)
+  cofsg(st, nvar, x0, fx, nnzg, nvar, gval, gvar, True)
   @test_approx_eq_eps fx[1] f(x0) 1e-8
   gx = zeros(nvar[1])
   for i = 1:nnzg[1]
@@ -47,34 +47,29 @@ if (ncon[1] > 0)
   end
   @test_approx_eq_eps gx g(x0) 1e-8
 
-  ccfg(st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True, nlp.cutest_lib)
+  ccfg(st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True)
   @test_approx_eq_eps Jtx J(x0)' 1e-8
-  ccfg(st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True, nlp.cutest_lib)
+  ccfg(st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True)
   @test_approx_eq_eps Jx J(x0) 1e-8
 
-  clfg(st, nvar, ncon, x0, y0, lx, glx, True, nlp.cutest_lib)
+  clfg(st, nvar, ncon, x0, y0, lx, glx, True)
   @test_approx_eq_eps lx[1] f(x0)+dot(y0,cx) 1e-8
   @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
 
-  cgr(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx,
-      nlp.cutest_lib)
+  cgr(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx)
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Jtx J(x0)' 1e-8
-  cgr(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx,
-      nlp.cutest_lib)
+  cgr(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx)
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
-  cgr(st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx,
-      nlp.cutest_lib)
+  cgr(st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx)
   @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
   @test_approx_eq_eps Jtx J(x0)' 1e-8
-  cgr(st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx,
-      nlp.cutest_lib)
+  cgr(st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx)
   @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
 
-  csgr(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun,
-      nlp.cutest_lib)
+  csgr(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun)
   glx = zeros(nvar[1])
   Jx = zeros(nvar[1], ncon[1])
   for k = 1:nnzj[1]
@@ -86,8 +81,7 @@ if (ncon[1] > 0)
   end
   @test_approx_eq_eps glx g(x0)+J(x0)'*y0 1e-8
   @test_approx_eq_eps Jtx J(x0)' 1e-8
-  csgr(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun,
-      nlp.cutest_lib)
+  csgr(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun)
   gx = zeros(nvar[1])
   Jx = zeros(ncon[1], nvar[1])
   for k = 1:nnzj[1]
@@ -100,8 +94,7 @@ if (ncon[1] > 0)
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
 
-  ccfsg(st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True,
-      nlp.cutest_lib)
+  ccfsg(st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True)
   Jx = zeros(ncon[1], nvar[1])
   for k = 1:nnzj[1]
     Jx[Jfun[k],Jvar[k]] = Jval[k]
@@ -110,7 +103,7 @@ if (ncon[1] > 0)
   @test_approx_eq_eps Jx J(x0) 1e-8
 
   for j = 1:ncon[1]
-    ccifg(st, nvar, Cint[j], x0, ci, gci, True, nlp.cutest_lib)
+    ccifg(st, nvar, Cint[j], x0, ci, gci, True)
     cx[j] = ci[1]
     Jx[j,:] = gci'
   end
@@ -119,8 +112,7 @@ if (ncon[1] > 0)
 
   Jx = zeros(ncon[1], nvar[1])
   for j = 1:ncon[1]
-    ccifsg(st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True,
-        nlp.cutest_lib)
+    ccifsg(st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True)
     cx[j] = ci[1]
     for k = 1:nnzj[1]
       Jx[j,Jvar[k]] = Jval[k]
@@ -130,30 +122,30 @@ if (ncon[1] > 0)
   @test_approx_eq_eps Jx J(x0) 1e-8
 
   cgrdh(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar,
-      Wx, nlp.cutest_lib)
+      Wx)
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
   cgrdh(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar,
-      Wx, nlp.cutest_lib)
+      Wx)
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Jtx J(x0)' 1e-8
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
   cgrdh(st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar,
-      Wx, nlp.cutest_lib)
+      Wx)
   @test_approx_eq_eps gx g(x0)+J(x0)'*y0 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
   cgrdh(st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar,
-      Wx, nlp.cutest_lib)
+      Wx)
   @test_approx_eq_eps gx g(x0)+J(x0)'*y0 1e-8
   @test_approx_eq_eps Jtx J(x0)' 1e-8
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
 
-  cdh(st, nvar, ncon, x0, y0, nvar, Wx, nlp.cutest_lib)
+  cdh(st, nvar, ncon, x0, y0, nvar, Wx)
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
 
-  csh(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+  csh(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
   Wx = zeros(nvar[1], nvar[1])
   for k = 1:nnzh[1]
     i = Hrow[k]; j = Hcol[k];
@@ -162,7 +154,7 @@ if (ncon[1] > 0)
   end
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
 
-  cshc(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+  cshc(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
   Cx = zeros(nvar[1], nvar[1])
   for k = 1:nnzh[1]
     i = Hrow[k]; j = Hcol[k];
@@ -171,17 +163,17 @@ if (ncon[1] > 0)
   end
   @test_approx_eq_eps Cx (W(x0,y0)-H(x0)) 1e-8
 
-  cidh(st, nvar, x0, Cint[0], nvar, Hx, nlp.cutest_lib)
+  cidh(st, nvar, x0, Cint[0], nvar, Hx)
   @test_approx_eq_eps Hx H(x0) 1e-8
   y1 = zeros(ncon[1])
   for k = 1:ncon[1]
-    cidh(st, nvar, x0, Cint[k], nvar, Cx, nlp.cutest_lib)
+    cidh(st, nvar, x0, Cint[k], nvar, Cx)
     y1[k] = 1.0
     @test_approx_eq_eps Cx (W(x0,y1)-H(x0)) 1e-8
     y1[k] = 0.0
   end
 
-  cish(st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+  cish(st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol)
   Hx = zeros(nvar[1], nvar[1])
   for k = 1:nnzh[1]
     i = Hrow[k]; j = Hcol[k];
@@ -191,7 +183,7 @@ if (ncon[1] > 0)
   @test_approx_eq_eps Hx H(x0) 1e-8
   y1 = zeros(ncon[1])
   for k = 1:ncon[1]
-    cish(st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+    cish(st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol)
     Cx = zeros(nvar[1], nvar[1])
     for k2 = 1:nnzh[1]
       i = Hrow[k2]; j = Hcol[k2];
@@ -204,7 +196,7 @@ if (ncon[1] > 0)
   end
 
   csgrsh(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun, nnzh,
-      lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+      lh, Hval, Hrow, Hcol)
   gx = zeros(nvar[1])
   Jx = zeros(ncon[1], nvar[1])
   for k = 1:nnzj[1]
@@ -224,7 +216,7 @@ if (ncon[1] > 0)
   @test_approx_eq_eps Jx J(x0) 1e-8
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
   csgrsh(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun, nnzh,
-      lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+      lh, Hval, Hrow, Hcol)
   glx = zeros(nvar[1])
   Jx = zeros(ncon[1], nvar[1])
   for k = 1:nnzj[1]
@@ -246,34 +238,32 @@ if (ncon[1] > 0)
 
   v = ones(nvar[1])
   Hv = Array(Cdouble, nvar[1])
-  chprod(st, nvar, ncon, False, x0, y0, v, Hv, nlp.cutest_lib)
+  chprod(st, nvar, ncon, False, x0, y0, v, Hv)
   @test_approx_eq_eps Hv W(x0,y0)*v 1e-8
 
   Hv = Array(Cdouble, nvar[1])
-  chcprod(st, nvar, ncon, False, x0, y0, v, Hv, nlp.cutest_lib)
+  chcprod(st, nvar, ncon, False, x0, y0, v, Hv)
   @test_approx_eq_eps Hv (W(x0,y0)-H(x0))*v 1e-8
 
   v = ones(nvar[1])
   Jv = Array(Cdouble, ncon[1])
-  cjprod(st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon,
-      nlp.cutest_lib)
+  cjprod(st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon)
   @test_approx_eq_eps Jv J(x0)*v 1e-8
   v = ones(ncon[1])
   Jtv = Array(Cdouble, nvar[1])
-  cjprod(st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar,
-      nlp.cutest_lib)
+  cjprod(st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar)
   @test_approx_eq_eps Jtv J(x0)'*v 1e-8
 else
-  ufn(st, nvar, x0, fx, nlp.cutest_lib)
+  ufn(st, nvar, x0, fx)
   @test_approx_eq_eps fx[1] f(x0) 1e-8
 
-  ugr(st, nvar, x0, gx, nlp.cutest_lib)
+  ugr(st, nvar, x0, gx)
   @test_approx_eq_eps gx g(x0) 1e-8
 
-  udh(st, nvar, x0, nvar, Hx, nlp.cutest_lib)
+  udh(st, nvar, x0, nvar, Hx)
   @test_approx_eq_eps Hx H(x0) 1e-8
 
-  ush(st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+  ush(st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol)
   Hx = zeros(nvar[1], nvar[1])
   for k = 1:nnzh[1]
     i = Hrow[k]; j = Hcol[k];
@@ -282,11 +272,11 @@ else
   end
   @test_approx_eq_eps Hx H(x0) 1e-8
 
-  ugrdh(st, nvar, x0, gx, nvar, Hx, nlp.cutest_lib)
+  ugrdh(st, nvar, x0, gx, nvar, Hx)
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Hx H(x0) 1e-8
 
-  ugrsh(st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+  ugrsh(st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol)
   @test_approx_eq_eps gx g(x0) 1e-8
   Hx = zeros(nvar[1], nvar[1])
   for k = 1:nnzh[1]
@@ -298,10 +288,10 @@ else
 
   v = ones(nvar[1])
   Hv = Array(Cdouble, nvar[1])
-  uhprod(st, nvar, False, x0, v, Hv, nlp.cutest_lib)
+  uhprod(st, nvar, False, x0, v, Hv)
   @test_approx_eq_eps Hv H(x0)*v 1e-8
 
-  uofg(st, nvar, x0, fx, gx, True, nlp.cutest_lib)
+  uofg(st, nvar, x0, fx, gx, True)
   @test_approx_eq_eps fx[1] f(x0) 1e-8
   @test_approx_eq_eps gx g(x0) 1e-8
 end
@@ -320,71 +310,61 @@ end
 print("Core interface stress test... ")
 for i = 1:100000
   if (ncon[1] > 0)
-    cfn(st, nvar, ncon, x0, fx, cx, nlp.cutest_lib)
-    cofg(st, nvar, x0, fx, gx, True, nlp.cutest_lib)
-    cofsg(st, nvar, x0, fx, nnzg, nvar, gval, gvar, True, nlp.cutest_lib)
-    ccfg(st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True, nlp.cutest_lib)
-    ccfg(st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True, nlp.cutest_lib)
-    clfg(st, nvar, ncon, x0, y0, lx, glx, True, nlp.cutest_lib)
-    cgr(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx,
-    nlp.cutest_lib)
-    cgr(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx,
-    nlp.cutest_lib)
-    cgr(st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx,
-    nlp.cutest_lib)
-    cgr(st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx,
-    nlp.cutest_lib)
-    csgr(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun,
-    nlp.cutest_lib)
-    csgr(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun,
-    nlp.cutest_lib)
-    ccfsg(st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True,
-    nlp.cutest_lib)
+    cfn(st, nvar, ncon, x0, fx, cx)
+    cofg(st, nvar, x0, fx, gx, True)
+    cofsg(st, nvar, x0, fx, nnzg, nvar, gval, gvar, True)
+    ccfg(st, nvar, ncon, x0, cx, True, nvar, ncon, Jtx, True)
+    ccfg(st, nvar, ncon, x0, cx, False, ncon, nvar, Jx, True)
+    clfg(st, nvar, ncon, x0, y0, lx, glx, True)
+    cgr(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx)
+    cgr(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx)
+    cgr(st, nvar, ncon, x0, y0, True, glx, True, nvar, ncon, Jtx)
+    cgr(st, nvar, ncon, x0, y0, True, glx, False, ncon, nvar, Jx)
+    csgr(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun)
+    csgr(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun)
+    ccfsg(st, nvar, ncon, x0, cx, nnzj, lj, Jval, Jvar, Jfun, True)
     for j = 1:ncon[1]
-      ccifg(st, nvar, Cint[j], x0, ci, gci, True, nlp.cutest_lib)
+      ccifg(st, nvar, Cint[j], x0, ci, gci, True)
     end
     for j = 1:ncon[1]
-      ccifsg(st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True,
-      nlp.cutest_lib)
+      ccifsg(st, nvar, Cint[j], x0, ci, nnzj, lj, Jval, Jvar, True)
     end
     cgrdh(st, nvar, ncon, x0, y0, False, gx, False, ncon, nvar, Jx, nvar,
-    Wx, nlp.cutest_lib)
+    Wx)
     cgrdh(st, nvar, ncon, x0, y0, False, gx, True, nvar, ncon, Jtx, nvar,
-    Wx, nlp.cutest_lib)
+    Wx)
     cgrdh(st, nvar, ncon, x0, y0, True, gx, False, ncon, nvar, Jx, nvar,
-    Wx, nlp.cutest_lib)
+    Wx)
     cgrdh(st, nvar, ncon, x0, y0, True, gx, True, nvar, ncon, Jtx, nvar,
-    Wx, nlp.cutest_lib)
-    cdh(st, nvar, ncon, x0, y0, nvar, Wx, nlp.cutest_lib)
-    csh(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
-    cshc(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
-    cidh(st, nvar, x0, Cint[0], nvar, Hx, nlp.cutest_lib)
+    Wx)
+    cdh(st, nvar, ncon, x0, y0, nvar, Wx)
+    csh(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
+    cshc(st, nvar, ncon, x0, y0, nnzh, lh, Hval, Hrow, Hcol)
+    cidh(st, nvar, x0, Cint[0], nvar, Hx)
     for k = 1:ncon[1]
-      cidh(st, nvar, x0, Cint[k], nvar, Cx, nlp.cutest_lib)
+      cidh(st, nvar, x0, Cint[k], nvar, Cx)
     end
-    cish(st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+    cish(st, nvar, x0, Cint[0], nnzh, lh, Hval, Hrow, Hcol)
     for k = 1:ncon[1]
-      cish(st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+      cish(st, nvar, x0, Cint[k], nnzh, lh, Hval, Hrow, Hcol)
     end
     csgrsh(st, nvar, ncon, x0, y0, False, nnzj, lj, Jval, Jvar, Jfun, nnzh,
-    lh, Hval, Hrow, Hcol, nlp.cutest_lib)
+    lh, Hval, Hrow, Hcol)
     csgrsh(st, nvar, ncon, x0, y0, True, nnzj, lj, Jval, Jvar, Jfun, nnzh,
-    lh, Hval, Hrow, Hcol, nlp.cutest_lib)
-    chprod(st, nvar, ncon, False, x0, y0, v, Hv, nlp.cutest_lib)
-    chcprod(st, nvar, ncon, False, x0, y0, v, Hv, nlp.cutest_lib)
-    cjprod(st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon,
-    nlp.cutest_lib)
-    cjprod(st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar,
-    nlp.cutest_lib)
+    lh, Hval, Hrow, Hcol)
+    chprod(st, nvar, ncon, False, x0, y0, v, Hv)
+    chcprod(st, nvar, ncon, False, x0, y0, v, Hv)
+    cjprod(st, nvar, ncon, False, False, x0, v, nvar, Jv, ncon)
+    cjprod(st, nvar, ncon, False, True, x0, v, ncon, Jtv, nvar)
   else
-    ufn(st, nvar, x0, fx, nlp.cutest_lib)
-    ugr(st, nvar, x0, gx, nlp.cutest_lib)
-    udh(st, nvar, x0, nvar, Hx, nlp.cutest_lib)
-    ush(st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
-    ugrdh(st, nvar, x0, gx, nvar, Hx, nlp.cutest_lib)
-    ugrsh(st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol, nlp.cutest_lib)
-    uhprod(st, nvar, False, x0, v, Hv, nlp.cutest_lib)
-    uofg(st, nvar, x0, fx, gx, True, nlp.cutest_lib)
+    ufn(st, nvar, x0, fx)
+    ugr(st, nvar, x0, gx)
+    udh(st, nvar, x0, nvar, Hx)
+    ush(st, nvar, x0, nnzh, lh, Hval, Hrow, Hcol)
+    ugrdh(st, nvar, x0, gx, nvar, Hx)
+    ugrsh(st, nvar, x0, gx, nnzh, lh, Hval, Hrow, Hcol)
+    uhprod(st, nvar, False, x0, v, Hv)
+    uofg(st, nvar, x0, fx, gx, True)
   end
 end
 println("passed")

--- a/test/test_specialized.jl
+++ b/test/test_specialized.jl
@@ -2,12 +2,12 @@ println("\nTesting the Specialized interface\n")
 
 v = ones(nlp.meta.nvar)
 if nlp.meta.ncon > 0
-  fx, cx = cfn(nlp.meta.nvar, nlp.meta.ncon, x0, nlp.cutest_lib)
+  fx, cx = cfn(nlp.meta.nvar, nlp.meta.ncon, x0)
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps cx c(x0) 1e-8
 
   cx = zeros(nlp.meta.ncon)
-  fx = cfn!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.cutest_lib)
+  fx = cfn!(nlp.meta.nvar, nlp.meta.ncon, x0, cx)
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps cx c(x0) 1e-8
 
@@ -20,12 +20,12 @@ if nlp.meta.ncon > 0
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps cx c(x0) 1e-8
 
-  fx, gx = cofg(nlp.meta.nvar, x0, true, nlp.cutest_lib)
+  fx, gx = cofg(nlp.meta.nvar, x0, true)
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps gx g(x0) 1e-8
 
   gx = zeros(nlp.meta.nvar)
-  fx = cofg!(nlp.meta.nvar, x0, gx, true, nlp.cutest_lib)
+  fx = cofg!(nlp.meta.nvar, x0, gx, true)
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps gx g(x0) 1e-8
 
@@ -38,19 +38,19 @@ if nlp.meta.ncon > 0
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps gx g(x0) 1e-8
 
-  fx, nnzg, g_val, g_var = cofsg(nlp.meta.nvar, x0, nlp.meta.nvar, true, nlp.cutest_lib)
+  fx, nnzg, g_val, g_var = cofsg(nlp.meta.nvar, x0, nlp.meta.nvar, true)
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps g_val g(x0)[g_var] 1e-8
 
   g_var = zeros(Int, nlp.meta.nvar)
   g_val = zeros(nlp.meta.nvar)
-  fx, nnzg = cofsg!(nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true, nlp.cutest_lib)
+  fx, nnzg = cofsg!(nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true)
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps g_val g(x0)[g_var] 1e-8
 
   g_var = zeros(Cint, nlp.meta.nvar)
   g_val = zeros(nlp.meta.nvar)
-  fx, nnzg = cofsg!(nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true, nlp.cutest_lib)
+  fx, nnzg = cofsg!(nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true)
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps g_val g(x0)[g_var] 1e-8
 
@@ -70,13 +70,13 @@ if nlp.meta.ncon > 0
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps g_val g(x0)[g_var] 1e-8
 
-  cx, Jx = ccfg(nlp.meta.nvar, nlp.meta.ncon, x0, false, nlp.meta.ncon, nlp.meta.nvar, true, nlp.cutest_lib)
+  cx, Jx = ccfg(nlp.meta.nvar, nlp.meta.ncon, x0, false, nlp.meta.ncon, nlp.meta.nvar, true)
   @test_approx_eq_eps cx c(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
 
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
-  ccfg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, true, nlp.cutest_lib)
+  ccfg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, true)
   @test_approx_eq_eps cx c(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
 
@@ -90,11 +90,11 @@ if nlp.meta.ncon > 0
   @test_approx_eq_eps cx c(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
 
-  fx, gx = clfg(nlp.meta.nvar, nlp.meta.ncon, x0, y0, true, nlp.cutest_lib)
+  fx, gx = clfg(nlp.meta.nvar, nlp.meta.ncon, x0, y0, true)
   @test_approx_eq_eps fx f(x0)+dot(y0,c(x0)) 1e-8
   @test_approx_eq_eps gx g(x0)+J(x0)'*y0 1e-8
 
-  fx = clfg!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, gx, true, nlp.cutest_lib)
+  fx = clfg!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, gx, true)
   @test_approx_eq_eps fx f(x0)+dot(y0,c(x0)) 1e-8
   @test_approx_eq_eps gx g(x0)+J(x0)'*y0 1e-8
 
@@ -106,13 +106,13 @@ if nlp.meta.ncon > 0
   @test_approx_eq_eps fx f(x0)+dot(y0,c(x0)) 1e-8
   @test_approx_eq_eps gx g(x0)+J(x0)'*y0 1e-8
 
-  gx, Jx = cgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.cutest_lib)
+  gx, Jx = cgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar)
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
 
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   gx = zeros(nlp.meta.nvar)
-  cgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.cutest_lib)
+  cgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx)
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
 
@@ -126,7 +126,7 @@ if nlp.meta.ncon > 0
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
 
-  nnzj, Jx, j_var, j_fun = csgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, nlp.cutest_lib)
+  nnzj, Jx, j_var, j_fun = csgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   for k = 1:nnzj
@@ -138,7 +138,7 @@ if nlp.meta.ncon > 0
   j_fun = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   Jx = zeros(nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj = csgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.cutest_lib)
+  nnzj = csgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   for k = 1:nnzj
@@ -150,7 +150,7 @@ if nlp.meta.ncon > 0
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   Jx = zeros(nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj = csgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.cutest_lib)
+  nnzj = csgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   for k = 1:nnzj
@@ -192,7 +192,7 @@ if nlp.meta.ncon > 0
   end
   @test_approx_eq_eps Jx J(x0) 1e-8
 
-  cx, nnzj, Jx, j_var, j_fun = ccfsg(nlp.meta.nvar, nlp.meta.ncon, x0, nlp.meta.nnzj+nlp.meta.nvar, true, nlp.cutest_lib)
+  cx, nnzj, Jx, j_var, j_fun = ccfsg(nlp.meta.nvar, nlp.meta.ncon, x0, nlp.meta.nnzj+nlp.meta.nvar, true)
   @test_approx_eq_eps cx c(x0) 1e-8
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
@@ -205,7 +205,7 @@ if nlp.meta.ncon > 0
   j_var = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   Jx = zeros(nlp.meta.nnzj+nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
-  nnzj = ccfsg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true, nlp.cutest_lib)
+  nnzj = ccfsg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true)
   @test_approx_eq_eps cx c(x0) 1e-8
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
@@ -218,7 +218,7 @@ if nlp.meta.ncon > 0
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   Jx = zeros(nlp.meta.nnzj+nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
-  nnzj = ccfsg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true, nlp.cutest_lib)
+  nnzj = ccfsg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true)
   @test_approx_eq_eps cx c(x0) 1e-8
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
@@ -263,13 +263,13 @@ if nlp.meta.ncon > 0
   @test_approx_eq_eps Jx J(x0) 1e-8
 
   for j = 1:nlp.meta.ncon
-    ci, gci = ccifg(nlp.meta.nvar, j, x0, true, nlp.cutest_lib)
+    ci, gci = ccifg(nlp.meta.nvar, j, x0, true)
     @test_approx_eq_eps ci c(x0)[j] 1e-8
     @test_approx_eq_eps gci J(x0)[j,:] 1e-8
   end
 
   for j = 1:nlp.meta.ncon
-    ci = ccifg!(nlp.meta.nvar, j, x0, gci, true, nlp.cutest_lib)
+    ci = ccifg!(nlp.meta.nvar, j, x0, gci, true)
     @test_approx_eq_eps ci c(x0)[j] 1e-8
   end
 
@@ -285,7 +285,7 @@ if nlp.meta.ncon > 0
   end
 
   for j = 1:nlp.meta.ncon
-    ci, nnzgci, gci_val, gci_var = ccifsg(nlp.meta.nvar, j, x0, nlp.meta.nvar, true, nlp.cutest_lib)
+    ci, nnzgci, gci_val, gci_var = ccifsg(nlp.meta.nvar, j, x0, nlp.meta.nvar, true)
     @test_approx_eq_eps ci c(x0)[j] 1e-8
     @test_approx_eq_eps gci_val J(x0)[j,gci_var] 1e-8
   end
@@ -293,7 +293,7 @@ if nlp.meta.ncon > 0
   for j = 1:nlp.meta.ncon
     gci_var = zeros(Int, nlp.meta.nvar)
     gci_val = zeros(nlp.meta.nvar)
-    ci, nnzgci = ccifsg!(nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true, nlp.cutest_lib)
+    ci, nnzgci = ccifsg!(nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true)
     @test_approx_eq_eps ci c(x0)[j] 1e-8
     @test_approx_eq_eps gci_val J(x0)[j,gci_var] 1e-8
   end
@@ -301,7 +301,7 @@ if nlp.meta.ncon > 0
   for j = 1:nlp.meta.ncon
     gci_var = zeros(Cint, nlp.meta.nvar)
     gci_val = zeros(nlp.meta.nvar)
-    ci, nnzgci = ccifsg!(nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true, nlp.cutest_lib)
+    ci, nnzgci = ccifsg!(nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true)
     @test_approx_eq_eps ci c(x0)[j] 1e-8
     @test_approx_eq_eps gci_val J(x0)[j,gci_var] 1e-8
   end
@@ -328,7 +328,7 @@ if nlp.meta.ncon > 0
     @test_approx_eq_eps gci_val J(x0)[j,gci_var] 1e-8
   end
 
-  gx, Jx, Wx = cgrdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.meta.nvar, nlp.cutest_lib)
+  gx, Jx, Wx = cgrdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.meta.nvar)
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
@@ -336,7 +336,7 @@ if nlp.meta.ncon > 0
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   gx = zeros(nlp.meta.nvar)
-  cgrdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.meta.nvar, Wx, nlp.cutest_lib)
+  cgrdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.meta.nvar, Wx)
   @test_approx_eq_eps gx g(x0) 1e-8
   @test_approx_eq_eps Jx J(x0) 1e-8
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
@@ -354,11 +354,11 @@ if nlp.meta.ncon > 0
   @test_approx_eq_eps Jx J(x0) 1e-8
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
 
-  Wx = cdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar, nlp.cutest_lib)
+  Wx = cdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar)
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
 
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
-  cdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar, Wx, nlp.cutest_lib)
+  cdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar, Wx)
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
 
   Wx = cdh(nlp, x0, y0, nlp.meta.nvar)
@@ -368,7 +368,7 @@ if nlp.meta.ncon > 0
   cdh!(nlp, x0, y0, nlp.meta.nvar, Wx)
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
 
-  nnzh, Wx, h_row, h_col = csh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, nlp.cutest_lib)
+  nnzh, Wx, h_row, h_col = csh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -380,7 +380,7 @@ if nlp.meta.ncon > 0
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
   Wx = zeros(nlp.meta.nnzh)
-  nnzh = csh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = csh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -392,7 +392,7 @@ if nlp.meta.ncon > 0
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
   Wx = zeros(nlp.meta.nnzh)
-  nnzh = csh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = csh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -434,7 +434,7 @@ if nlp.meta.ncon > 0
   end
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
 
-  nnzh, Wx, h_row, h_col = cshc(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, nlp.cutest_lib)
+  nnzh, Wx, h_row, h_col = cshc(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -446,7 +446,7 @@ if nlp.meta.ncon > 0
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
   Wx = zeros(nlp.meta.nnzh)
-  nnzh = cshc!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = cshc!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -458,7 +458,7 @@ if nlp.meta.ncon > 0
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
   Wx = zeros(nlp.meta.nnzh)
-  nnzh = cshc!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = cshc!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -501,13 +501,13 @@ if nlp.meta.ncon > 0
   @test_approx_eq_eps Wx W(x0,y0)-H(x0) 1e-8
 
   for j = 1:nlp.meta.ncon
-    h = cidh(nlp.meta.nvar, x0, j, nlp.meta.nvar, nlp.cutest_lib)
+    h = cidh(nlp.meta.nvar, x0, j, nlp.meta.nvar)
     @test_approx_eq_eps h (W(x0,[i == j ? 1.0 : 0.0 for i = 1:nlp.meta.ncon])-H(x0)) 1e-8
   end
 
   for j = 1:nlp.meta.ncon
     h = zeros(nlp.meta.nvar, nlp.meta.nvar)
-    cidh!(nlp.meta.nvar, x0, j, nlp.meta.nvar, h, nlp.cutest_lib)
+    cidh!(nlp.meta.nvar, x0, j, nlp.meta.nvar, h)
     @test_approx_eq_eps h (W(x0,[i == j ? 1.0 : 0.0 for i = 1:nlp.meta.ncon])-H(x0)) 1e-8
   end
 
@@ -523,7 +523,7 @@ if nlp.meta.ncon > 0
   end
 
   for j = 1:nlp.meta.ncon
-    nnzh, Wx, h_row, h_col = cish(nlp.meta.nvar, x0, j, nlp.meta.nnzh, nlp.cutest_lib)
+    nnzh, Wx, h_row, h_col = cish(nlp.meta.nvar, x0, j, nlp.meta.nnzh)
     w_val = copy(Wx)
     Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
     for k = 1:nnzh
@@ -537,7 +537,7 @@ if nlp.meta.ncon > 0
     h_col = zeros(Int, nlp.meta.nnzh)
     h_row = zeros(Int, nlp.meta.nnzh)
     Wx = zeros(nlp.meta.nnzh)
-    nnzh = cish!(nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+    nnzh = cish!(nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col)
     w_val = copy(Wx)
     Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
     for k = 1:nnzh
@@ -551,7 +551,7 @@ if nlp.meta.ncon > 0
     h_col = zeros(Cint, nlp.meta.nnzh)
     h_row = zeros(Cint, nlp.meta.nnzh)
     Wx = zeros(nlp.meta.nnzh)
-    nnzh = cish!(nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+    nnzh = cish!(nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col)
     w_val = copy(Wx)
     Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
     for k = 1:nnzh
@@ -600,7 +600,7 @@ if nlp.meta.ncon > 0
     @test_approx_eq_eps Wx W(x0,[i == j ? 1.0 : 0.0 for i = 1:nlp.meta.ncon])-H(x0) 1e-8
   end
 
-  nnzj, Jx, j_var, j_fun, nnzh, Wx, h_row, h_col = csgrsh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, nlp.meta.nnzh, nlp.cutest_lib)
+  nnzj, Jx, j_var, j_fun, nnzh, Wx, h_row, h_col = csgrsh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, nlp.meta.nnzh)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   for k = 1:nnzj
@@ -623,7 +623,7 @@ if nlp.meta.ncon > 0
   j_fun = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   Jx = zeros(nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj, nnzh = csgrsh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzj, nnzh = csgrsh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   for k = 1:nnzj
@@ -646,7 +646,7 @@ if nlp.meta.ncon > 0
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   Jx = zeros(nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj, nnzh = csgrsh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzj, nnzh = csgrsh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col)
   j_val = copy(Jx)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   for k = 1:nnzj
@@ -726,11 +726,11 @@ if nlp.meta.ncon > 0
   end
   @test_approx_eq_eps Wx W(x0,y0) 1e-8
 
-  result = chprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), nlp.cutest_lib)
+  result = chprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
   @test_approx_eq_eps result W(x0,y0)*v 1e-8
 
   result = zeros(W(x0,y0)*v)
-  chprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result, nlp.cutest_lib)
+  chprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
 
   result = chprod(nlp, false, x0, y0, ones(nlp.meta.nvar))
   @test_approx_eq_eps result W(x0,y0)*v 1e-8
@@ -738,11 +738,11 @@ if nlp.meta.ncon > 0
   result = zeros(W(x0,y0)*v)
   chprod!(nlp, false, x0, y0, ones(nlp.meta.nvar), result)
 
-  result = chcprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), nlp.cutest_lib)
+  result = chcprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
   @test_approx_eq_eps result (W(x0,y0)-H(x0))*v 1e-8
 
   result = zeros((W(x0,y0)-H(x0))*v)
-  chcprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result, nlp.cutest_lib)
+  chcprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
 
   result = chcprod(nlp, false, x0, y0, ones(nlp.meta.nvar))
   @test_approx_eq_eps result (W(x0,y0)-H(x0))*v 1e-8
@@ -750,11 +750,11 @@ if nlp.meta.ncon > 0
   result = zeros((W(x0,y0)-H(x0))*v)
   chcprod!(nlp, false, x0, y0, ones(nlp.meta.nvar), result)
 
-  result = cjprod(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, nlp.meta.ncon, nlp.cutest_lib)
+  result = cjprod(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, nlp.meta.ncon)
   @test_approx_eq_eps result J(x0)*v 1e-8
 
   result = zeros(J(x0)*v)
-  cjprod!(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, result, nlp.meta.ncon, nlp.cutest_lib)
+  cjprod!(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, result, nlp.meta.ncon)
 
   result = cjprod(nlp, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, nlp.meta.ncon)
   @test_approx_eq_eps result J(x0)*v 1e-8
@@ -763,17 +763,17 @@ if nlp.meta.ncon > 0
   cjprod!(nlp, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, result, nlp.meta.ncon)
 
 else
-  fx = ufn(nlp.meta.nvar, x0, nlp.cutest_lib)
+  fx = ufn(nlp.meta.nvar, x0)
   @test_approx_eq_eps fx f(x0) 1e-8
 
   fx = ufn(nlp, x0)
   @test_approx_eq_eps fx f(x0) 1e-8
 
-  gx = ugr(nlp.meta.nvar, x0, nlp.cutest_lib)
+  gx = ugr(nlp.meta.nvar, x0)
   @test_approx_eq_eps gx g(x0) 1e-8
 
   gx = zeros(nlp.meta.nvar)
-  ugr!(nlp.meta.nvar, x0, gx, nlp.cutest_lib)
+  ugr!(nlp.meta.nvar, x0, gx)
   @test_approx_eq_eps gx g(x0) 1e-8
 
   gx = ugr(nlp, x0)
@@ -783,12 +783,12 @@ else
   ugr!(nlp, x0, gx)
   @test_approx_eq_eps gx g(x0) 1e-8
 
-  fx, gx = uofg(nlp.meta.nvar, x0, true, nlp.cutest_lib)
+  fx, gx = uofg(nlp.meta.nvar, x0, true)
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps gx g(x0) 1e-8
 
   gx = zeros(nlp.meta.nvar)
-  fx = uofg!(nlp.meta.nvar, x0, gx, true, nlp.cutest_lib)
+  fx = uofg!(nlp.meta.nvar, x0, gx, true)
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps gx g(x0) 1e-8
 
@@ -801,10 +801,10 @@ else
   @test_approx_eq_eps fx f(x0) 1e-8
   @test_approx_eq_eps gx g(x0) 1e-8
 
-  h = udh(nlp.meta.nvar, x0, nlp.meta.nvar, nlp.cutest_lib)
+  h = udh(nlp.meta.nvar, x0, nlp.meta.nvar)
   @test_approx_eq_eps h H(x0) 1e-8
 
-  udh!(nlp.meta.nvar, x0, nlp.meta.nvar, h, nlp.cutest_lib)
+  udh!(nlp.meta.nvar, x0, nlp.meta.nvar, h)
   @test_approx_eq_eps h H(x0) 1e-8
 
   h = udh(nlp, x0, nlp.meta.nvar)
@@ -813,7 +813,7 @@ else
   udh!(nlp, x0, nlp.meta.nvar, h)
   @test_approx_eq_eps h H(x0) 1e-8
 
-  nnzh, Wx, h_row, h_col = ush(nlp.meta.nvar, x0, nlp.meta.nnzh, nlp.cutest_lib)
+  nnzh, Wx, h_row, h_col = ush(nlp.meta.nvar, x0, nlp.meta.nnzh)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -825,7 +825,7 @@ else
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
   Wx = zeros(nlp.meta.nnzh)
-  nnzh = ush!(nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = ush!(nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -837,7 +837,7 @@ else
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
   Wx = zeros(nlp.meta.nnzh)
-  nnzh = ush!(nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = ush!(nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col)
   w_val = copy(Wx)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for k = 1:nnzh
@@ -879,11 +879,11 @@ else
   end
   @test_approx_eq_eps Wx H(x0) 1e-8
 
-  result = uhprod(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar), nlp.cutest_lib)
+  result = uhprod(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar))
   @test_approx_eq_eps result H(x0)*v 1e-8
 
   result = zeros(H(x0)*v)
-  uhprod!(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar), result, nlp.cutest_lib)
+  uhprod!(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar), result)
 
   result = uhprod(nlp, false, x0, ones(nlp.meta.nvar))
   @test_approx_eq_eps result H(x0)*v 1e-8
@@ -896,25 +896,25 @@ end
 print("Specialized interface stress test... ")
 for i = 1:100000
   if nlp.meta.ncon > 0
-  fx, cx = cfn(nlp.meta.nvar, nlp.meta.ncon, x0, nlp.cutest_lib)
+  fx, cx = cfn(nlp.meta.nvar, nlp.meta.ncon, x0)
   cx = zeros(nlp.meta.ncon)
-  fx = cfn!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.cutest_lib)
+  fx = cfn!(nlp.meta.nvar, nlp.meta.ncon, x0, cx)
   fx, cx = cfn(nlp, x0)
   cx = zeros(nlp.meta.ncon)
   fx = cfn!(nlp, x0, cx)
-  fx, gx = cofg(nlp.meta.nvar, x0, true, nlp.cutest_lib)
+  fx, gx = cofg(nlp.meta.nvar, x0, true)
   gx = zeros(nlp.meta.nvar)
-  fx = cofg!(nlp.meta.nvar, x0, gx, true, nlp.cutest_lib)
+  fx = cofg!(nlp.meta.nvar, x0, gx, true)
   fx, gx = cofg(nlp, x0, true)
   gx = zeros(nlp.meta.nvar)
   fx = cofg!(nlp, x0, gx, true)
-  fx, nnzg, g_val, g_var = cofsg(nlp.meta.nvar, x0, nlp.meta.nvar, true, nlp.cutest_lib)
+  fx, nnzg, g_val, g_var = cofsg(nlp.meta.nvar, x0, nlp.meta.nvar, true)
   g_var = zeros(Int, nlp.meta.nvar)
   g_val = zeros(nlp.meta.nvar)
-  fx, nnzg = cofsg!(nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true, nlp.cutest_lib)
+  fx, nnzg = cofsg!(nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true)
   g_var = zeros(Cint, nlp.meta.nvar)
   g_val = zeros(nlp.meta.nvar)
-  fx, nnzg = cofsg!(nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true, nlp.cutest_lib)
+  fx, nnzg = cofsg!(nlp.meta.nvar, x0, nlp.meta.nvar, g_val, g_var, true)
   fx, nnzg, g_val, g_var = cofsg(nlp, x0, nlp.meta.nvar, true)
   g_var = zeros(Int, nlp.meta.nvar)
   g_val = zeros(nlp.meta.nvar)
@@ -922,33 +922,33 @@ for i = 1:100000
   g_var = zeros(Cint, nlp.meta.nvar)
   g_val = zeros(nlp.meta.nvar)
   fx, nnzg = cofsg!(nlp, x0, nlp.meta.nvar, g_val, g_var, true)
-  cx, Jx = ccfg(nlp.meta.nvar, nlp.meta.ncon, x0, false, nlp.meta.ncon, nlp.meta.nvar, true, nlp.cutest_lib)
+  cx, Jx = ccfg(nlp.meta.nvar, nlp.meta.ncon, x0, false, nlp.meta.ncon, nlp.meta.nvar, true)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
-  ccfg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, true, nlp.cutest_lib)
+  ccfg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, true)
   cx, Jx = ccfg(nlp, x0, false, nlp.meta.ncon, nlp.meta.nvar, true)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
   ccfg!(nlp, x0, cx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, true)
-  fx, gx = clfg(nlp.meta.nvar, nlp.meta.ncon, x0, y0, true, nlp.cutest_lib)
-  fx = clfg!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, gx, true, nlp.cutest_lib)
+  fx, gx = clfg(nlp.meta.nvar, nlp.meta.ncon, x0, y0, true)
+  fx = clfg!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, gx, true)
   fx, gx = clfg(nlp, x0, y0, true)
   fx = clfg!(nlp, x0, y0, gx, true)
-  gx, Jx = cgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.cutest_lib)
+  gx, Jx = cgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   gx = zeros(nlp.meta.nvar)
-  cgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.cutest_lib)
+  cgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx)
   gx, Jx = cgr(nlp, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   gx = zeros(nlp.meta.nvar)
   cgr!(nlp, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx)
-  nnzj, Jx, j_var, j_fun = csgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, nlp.cutest_lib)
+  nnzj, Jx, j_var, j_fun = csgr(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar)
   j_fun = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj = csgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.cutest_lib)
+  nnzj = csgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun)
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj = csgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.cutest_lib)
+  nnzj = csgr!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun)
   nnzj, Jx, j_var, j_fun = csgr(nlp, x0, y0, false)
   j_fun = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
@@ -956,15 +956,15 @@ for i = 1:100000
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   nnzj = csgr!(nlp, x0, y0, false, Jx, j_var, j_fun)
-  cx, nnzj, Jx, j_var, j_fun = ccfsg(nlp.meta.nvar, nlp.meta.ncon, x0, nlp.meta.nnzj+nlp.meta.nvar, true, nlp.cutest_lib)
+  cx, nnzj, Jx, j_var, j_fun = ccfsg(nlp.meta.nvar, nlp.meta.ncon, x0, nlp.meta.nnzj+nlp.meta.nvar, true)
   j_fun = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
-  nnzj = ccfsg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true, nlp.cutest_lib)
+  nnzj = ccfsg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true)
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   cx = zeros(nlp.meta.ncon)
-  nnzj = ccfsg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true, nlp.cutest_lib)
+  nnzj = ccfsg!(nlp.meta.nvar, nlp.meta.ncon, x0, cx, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, true)
   cx, nnzj, Jx, j_var, j_fun = ccfsg(nlp, x0, true)
   j_fun = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
@@ -975,10 +975,10 @@ for i = 1:100000
   cx = zeros(nlp.meta.ncon)
   nnzj = ccfsg!(nlp, x0, cx, Jx, j_var, j_fun, true)
   for j = 1:nlp.meta.ncon
-    ci, gci = ccifg(nlp.meta.nvar, j, x0, true, nlp.cutest_lib)
+    ci, gci = ccifg(nlp.meta.nvar, j, x0, true)
   end
   for j = 1:nlp.meta.ncon
-    ci = ccifg!(nlp.meta.nvar, j, x0, gci, true, nlp.cutest_lib)
+    ci = ccifg!(nlp.meta.nvar, j, x0, gci, true)
   end
   for j = 1:nlp.meta.ncon
     ci, gci = ccifg(nlp, j, x0, true)
@@ -987,17 +987,17 @@ for i = 1:100000
     ci = ccifg!(nlp, j, x0, gci, true)
   end
   for j = 1:nlp.meta.ncon
-    ci, nnzgci, gci_val, gci_var = ccifsg(nlp.meta.nvar, j, x0, nlp.meta.nvar, true, nlp.cutest_lib)
+    ci, nnzgci, gci_val, gci_var = ccifsg(nlp.meta.nvar, j, x0, nlp.meta.nvar, true)
   end
     gci_var = zeros(Int, nlp.meta.nvar)
     gci_val = zeros(nlp.meta.nvar)
   for j = 1:nlp.meta.ncon
-    ci, nnzgci = ccifsg!(nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true, nlp.cutest_lib)
+    ci, nnzgci = ccifsg!(nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true)
   end
     gci_var = zeros(Cint, nlp.meta.nvar)
     gci_val = zeros(nlp.meta.nvar)
   for j = 1:nlp.meta.ncon
-    ci, nnzgci = ccifsg!(nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true, nlp.cutest_lib)
+    ci, nnzgci = ccifsg!(nlp.meta.nvar, j, x0, nlp.meta.nvar, gci_val, gci_var, true)
   end
   for j = 1:nlp.meta.ncon
     ci, nnzgci, gci_val, gci_var = ccifsg(nlp, j, x0, nlp.meta.nvar, true)
@@ -1012,29 +1012,29 @@ for i = 1:100000
   for j = 1:nlp.meta.ncon
     ci, nnzgci = ccifsg!(nlp, j, x0, nlp.meta.nvar, gci_val, gci_var, true)
   end
-  gx, Jx, Wx = cgrdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.meta.nvar, nlp.cutest_lib)
+  gx, Jx, Wx = cgrdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.meta.nvar)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   gx = zeros(nlp.meta.nvar)
-  cgrdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.meta.nvar, Wx, nlp.cutest_lib)
+  cgrdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.meta.nvar, Wx)
   gx, Jx, Wx = cgrdh(nlp, x0, y0, false, false, nlp.meta.ncon, nlp.meta.nvar, nlp.meta.nvar)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   Jx = zeros(nlp.meta.ncon, nlp.meta.nvar)
   gx = zeros(nlp.meta.nvar)
   cgrdh!(nlp, x0, y0, false, gx, false, nlp.meta.ncon, nlp.meta.nvar, Jx, nlp.meta.nvar, Wx)
-  Wx = cdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar, nlp.cutest_lib)
+  Wx = cdh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
-  cdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar, Wx, nlp.cutest_lib)
+  cdh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nvar, Wx)
   Wx = cdh(nlp, x0, y0, nlp.meta.nvar)
   Wx = zeros(nlp.meta.nvar, nlp.meta.nvar)
   cdh!(nlp, x0, y0, nlp.meta.nvar, Wx)
-  nnzh, Wx, h_row, h_col = csh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, nlp.cutest_lib)
+  nnzh, Wx, h_row, h_col = csh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
-  nnzh = csh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = csh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
-  nnzh = csh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = csh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   nnzh, Wx, h_row, h_col = csh(nlp, x0, y0)
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
@@ -1042,13 +1042,13 @@ for i = 1:100000
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
   nnzh = csh!(nlp, x0, y0, Wx, h_row, h_col)
-  nnzh, Wx, h_row, h_col = cshc(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, nlp.cutest_lib)
+  nnzh, Wx, h_row, h_col = cshc(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh)
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
-  nnzh = cshc!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = cshc!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
-  nnzh = cshc!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = cshc!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, nlp.meta.nnzh, Wx, h_row, h_col)
   nnzh, Wx, h_row, h_col = cshc(nlp, x0, y0)
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
@@ -1057,11 +1057,11 @@ for i = 1:100000
   h_row = zeros(Cint, nlp.meta.nnzh)
   nnzh = cshc!(nlp, x0, y0, Wx, h_row, h_col)
   for j = 1:nlp.meta.ncon
-    h = cidh(nlp.meta.nvar, x0, j, nlp.meta.nvar, nlp.cutest_lib)
+    h = cidh(nlp.meta.nvar, x0, j, nlp.meta.nvar)
   end
     h = zeros(nlp.meta.nvar, nlp.meta.nvar)
   for j = 1:nlp.meta.ncon
-    cidh!(nlp.meta.nvar, x0, j, nlp.meta.nvar, h, nlp.cutest_lib)
+    cidh!(nlp.meta.nvar, x0, j, nlp.meta.nvar, h)
   end
   for j = 1:nlp.meta.ncon
     h = cidh(nlp, x0, j, nlp.meta.nvar)
@@ -1071,17 +1071,17 @@ for i = 1:100000
     cidh!(nlp, x0, j, nlp.meta.nvar, h)
   end
   for j = 1:nlp.meta.ncon
-    nnzh, Wx, h_row, h_col = cish(nlp.meta.nvar, x0, j, nlp.meta.nnzh, nlp.cutest_lib)
+    nnzh, Wx, h_row, h_col = cish(nlp.meta.nvar, x0, j, nlp.meta.nnzh)
   end
     h_col = zeros(Int, nlp.meta.nnzh)
     h_row = zeros(Int, nlp.meta.nnzh)
   for j = 1:nlp.meta.ncon
-    nnzh = cish!(nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+    nnzh = cish!(nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col)
   end
     h_col = zeros(Cint, nlp.meta.nnzh)
     h_row = zeros(Cint, nlp.meta.nnzh)
   for j = 1:nlp.meta.ncon
-    nnzh = cish!(nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+    nnzh = cish!(nlp.meta.nvar, x0, j, nlp.meta.nnzh, Wx, h_row, h_col)
   end
   for j = 1:nlp.meta.ncon
     nnzh, Wx, h_row, h_col = cish(nlp, x0, j)
@@ -1096,17 +1096,17 @@ for i = 1:100000
   for j = 1:nlp.meta.ncon
     nnzh = cish!(nlp, x0, j, Wx, h_row, h_col)
   end
-  nnzj, Jx, j_var, j_fun, nnzh, Wx, h_row, h_col = csgrsh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, nlp.meta.nnzh, nlp.cutest_lib)
+  nnzj, Jx, j_var, j_fun, nnzh, Wx, h_row, h_col = csgrsh(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, nlp.meta.nnzh)
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
   j_fun = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Int, nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj, nnzh = csgrsh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzj, nnzh = csgrsh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col)
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
-  nnzj, nnzh = csgrsh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzj, nnzh = csgrsh!(nlp.meta.nvar, nlp.meta.ncon, x0, y0, false, nlp.meta.nnzj+nlp.meta.nvar, Jx, j_var, j_fun, nlp.meta.nnzh, Wx, h_row, h_col)
   nnzj, Jx, j_var, j_fun, nnzh, Wx, h_row, h_col = csgrsh(nlp, x0, y0, false)
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
@@ -1118,50 +1118,50 @@ for i = 1:100000
   j_fun = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   j_var = zeros(Cint, nlp.meta.nnzj+nlp.meta.nvar)
   nnzj, nnzh = csgrsh!(nlp, x0, y0, false, Jx, j_var, j_fun, Wx, h_row, h_col)
-  result = chprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), nlp.cutest_lib)
+  result = chprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
   result = zeros(W(x0,y0)*v)
-  chprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result, nlp.cutest_lib)
+  chprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
   result = chprod(nlp, false, x0, y0, ones(nlp.meta.nvar))
   result = zeros(W(x0,y0)*v)
   chprod!(nlp, false, x0, y0, ones(nlp.meta.nvar), result)
-  result = chcprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), nlp.cutest_lib)
+  result = chcprod(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar))
   result = zeros((W(x0,y0)-H(x0))*v)
-  chcprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result, nlp.cutest_lib)
+  chcprod!(nlp.meta.nvar, nlp.meta.ncon, false, x0, y0, ones(nlp.meta.nvar), result)
   result = chcprod(nlp, false, x0, y0, ones(nlp.meta.nvar))
   result = zeros((W(x0,y0)-H(x0))*v)
   chcprod!(nlp, false, x0, y0, ones(nlp.meta.nvar), result)
-  result = cjprod(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, nlp.meta.ncon, nlp.cutest_lib)
+  result = cjprod(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, nlp.meta.ncon)
   result = zeros(J(x0)*v)
-  cjprod!(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, result, nlp.meta.ncon, nlp.cutest_lib)
+  cjprod!(nlp.meta.nvar, nlp.meta.ncon, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, result, nlp.meta.ncon)
   result = cjprod(nlp, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, nlp.meta.ncon)
   result = zeros(J(x0)*v)
   cjprod!(nlp, false, false, x0, ones(nlp.meta.nvar), nlp.meta.nvar, result, nlp.meta.ncon)
   else
-  fx = ufn(nlp.meta.nvar, x0, nlp.cutest_lib)
+  fx = ufn(nlp.meta.nvar, x0)
   fx = ufn(nlp, x0)
-  gx = ugr(nlp.meta.nvar, x0, nlp.cutest_lib)
+  gx = ugr(nlp.meta.nvar, x0)
   gx = zeros(nlp.meta.nvar)
-  ugr!(nlp.meta.nvar, x0, gx, nlp.cutest_lib)
+  ugr!(nlp.meta.nvar, x0, gx)
   gx = ugr(nlp, x0)
   gx = zeros(nlp.meta.nvar)
   ugr!(nlp, x0, gx)
-  fx, gx = uofg(nlp.meta.nvar, x0, true, nlp.cutest_lib)
+  fx, gx = uofg(nlp.meta.nvar, x0, true)
   gx = zeros(nlp.meta.nvar)
-  fx = uofg!(nlp.meta.nvar, x0, gx, true, nlp.cutest_lib)
+  fx = uofg!(nlp.meta.nvar, x0, gx, true)
   fx, gx = uofg(nlp, x0, true)
   gx = zeros(nlp.meta.nvar)
   fx = uofg!(nlp, x0, gx, true)
-  h = udh(nlp.meta.nvar, x0, nlp.meta.nvar, nlp.cutest_lib)
-  udh!(nlp.meta.nvar, x0, nlp.meta.nvar, h, nlp.cutest_lib)
+  h = udh(nlp.meta.nvar, x0, nlp.meta.nvar)
+  udh!(nlp.meta.nvar, x0, nlp.meta.nvar, h)
   h = udh(nlp, x0, nlp.meta.nvar)
   udh!(nlp, x0, nlp.meta.nvar, h)
-  nnzh, Wx, h_row, h_col = ush(nlp.meta.nvar, x0, nlp.meta.nnzh, nlp.cutest_lib)
+  nnzh, Wx, h_row, h_col = ush(nlp.meta.nvar, x0, nlp.meta.nnzh)
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
-  nnzh = ush!(nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = ush!(nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col)
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
-  nnzh = ush!(nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col, nlp.cutest_lib)
+  nnzh = ush!(nlp.meta.nvar, x0, nlp.meta.nnzh, Wx, h_row, h_col)
   nnzh, Wx, h_row, h_col = ush(nlp, x0)
   h_col = zeros(Int, nlp.meta.nnzh)
   h_row = zeros(Int, nlp.meta.nnzh)
@@ -1169,9 +1169,9 @@ for i = 1:100000
   h_col = zeros(Cint, nlp.meta.nnzh)
   h_row = zeros(Cint, nlp.meta.nnzh)
   nnzh = ush!(nlp, x0, Wx, h_row, h_col)
-  result = uhprod(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar), nlp.cutest_lib)
+  result = uhprod(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar))
   result = zeros(H(x0)*v)
-  uhprod!(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar), result, nlp.cutest_lib)
+  uhprod!(nlp.meta.nvar, false, x0, ones(nlp.meta.nvar), result)
   result = uhprod(nlp, false, x0, ones(nlp.meta.nvar))
   result = zeros(H(x0)*v)
   uhprod!(nlp, false, x0, ones(nlp.meta.nvar), result)

--- a/travisCI/setup_travis_linux.sh
+++ b/travisCI/setup_travis_linux.sh
@@ -3,7 +3,7 @@ set -ev
 
 # Install LinuxBrew.
 sudo apt-get update
-sudo apt-get install build-essential curl git m4 ruby texinfo libbz2-dev libcurl4-openssl-dev libexpat-dev libncurses-dev zlib1g-dev
+sudo apt-get install build-essential curl git m4 ruby texinfo libbz2-dev libcurl4-openssl-dev libexpat-dev libncurses-dev zlib1g-dev libgsl0-dev
 echo -ne '\n' | ruby -e "$(wget -O- https://raw.github.com/Homebrew/linuxbrew/go/install)"
 
 # Symlink GCC to avoid installing Homebrew GCC.


### PR DESCRIPTION
This allows opening one problem **after the other** without breaking.
Unfortunately, this prohibits the possibility of opening two problems **at the same time**.

Closes #4.

The most important changes are in `src/CUTEst.jl`. The libname or cutest_lib arguments are removed in favor of using a global variable.
Tested running **both** HS32 and HS4 verifying the values and by getting the objective function of **all** the CUTEst problems with the three interfaces (see `test/runtests.jl`).

The fix for travis (which allows failures of osx) is in a different commit.