### PR TITLE
Bindeps and AbstractNLPModel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.[df]
+*.so
+
+deps/*
+!deps/build.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,10 @@ julia:
 sudo: required
 
 before_install:
-  # Install Linuxbrew.
-  - if [ `uname` == "Linux" ]; then unset DYLD_LIBRARY_PATH; bash travisCI/setup_travis_linux.sh; export PATH="$HOME/.linuxbrew/bin:$PATH"; export LD_LIBRARY_PATH="$HOME/.linuxbrew/lib:$LD_LIBRARY_PATH"; export HOMEBREW_BUILD_FROM_SOURCE=1; fi
-  - brew --config
-  - brew doctor || true
-  - brew update
-  - if [ `uname` == "Linux" ]; then brew install pkg-config; fi
+  - if [ `uname` == "Linux" ]; then unset DYLD_LIBRARY_PATH; bash travisCI/setup_travis_linux.sh; fi
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 
 install:
-  # Install CUTEst.
-  - brew tap optimizers/cutest
-  - brew install cutest
-  - brew install mastsif
-  - for f in archdefs mastsif cutest sifdecode; do . $(brew --prefix $f)/$f.bashrc; done
-  - if [ `uname` == "Linux" ]; then rm ~/julia/lib/julia/libgfortran.so.3; fi
   - julia -e 'versioninfo()'
   - julia -E 'Pkg.clone(pwd());'
   - julia -E 'Pkg.build("CUTEst");'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ sudo: required
 before_install:
   - if [ `uname` == "Linux" ]; then unset DYLD_LIBRARY_PATH; bash travisCI/setup_travis_linux.sh; fi
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -E 'Pkg.clone("https://github.com/abelsiqueira/NLPModels.jl");
+    Pkg.checkout("NLPModels", "develop")'
 
 install:
   - julia -e 'versioninfo()'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 Compat
+@osx Homebrew
 MathProgBase

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -20,17 +20,19 @@ cd(dirname(@__FILE__))
 end
 
 @osx_only begin
-  try
-    run(`brew doctor`)
+  @eval using Homebrew
+
+  Homebrew.update()
+  Homebrew.add("homebrew/versions/gcc5")
+  ENV["CUTEST_GCC"] = "gcc-5"
+  ENV["CUTEST_GFORTRAN"] = "gfortran-5"
+  for p in ["archdefs", "cutest", "mastsif"]
+    Homebrew.add("optimizers/cutest/$p")
   end
-  run(`brew update`)
-  run(`brew tap optimizers/cutest`)
-  run(`brew install cutest`)
-  run(`brew install mastsif`)
 
   open("cutestenv.jl", "w") do cenv
     for p in ["archdefs", "cutest", "sifdecode", "mastsif"]
-      prefix = chomp(readall(`brew --prefix $p`))
+      prefix = Homebrew.prefix(p)
       open("$prefix/$p.bashrc") do f
         for line in readlines(f)
           var = split(split(line, "=")[1])[2]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,45 @@
+cd(dirname(@__FILE__))
+
+@linux_only begin
+  lnxurl = "https://raw.githubusercontent.com/abelsiqueira/linux-cutest/master/install.sh"
+  run(`wget $lnxurl -O install.sh`)
+  run(`bash install.sh`)
+
+  open("cutestenv.jl", "w") do cenv
+    open("cutest_env.bashrc") do f
+      for p in ["PATH", "MANPATH", "LD_LIBRARY_PATH"]
+        write(cenv, "$p = get(ENV, \"$p\", \"\")\n")
+      end
+      for line in readlines(f)
+        var = split(split(line, "=")[1])[2]
+        path = chomp(split(line, "=")[2])
+        write(cenv, "ENV[\"$var\"] = \"$path\"\n")
+      end
+    end
+  end
+end
+
+@osx_only begin
+  try
+    run(`brew doctor`)
+  end
+  run(`brew update`)
+  run(`brew tap optimizers/cutest`)
+  run(`brew install cutest`)
+  run(`brew install mastsif`)
+
+  open("cutestenv.jl", "w") do cenv
+    for p in ["archdefs", "cutest", "sifdecode", "mastsif"]
+      prefix = chomp(readall(`brew --prefix $p`))
+      open("$prefix/$p.bashrc") do f
+        for line in readlines(f)
+          var = split(split(line, "=")[1])[2]
+          path = chomp(split(line, "=")[2])
+          write(cenv, "ENV[\"$var\"] = \"$path\"\n")
+        end
+      end
+    end
+  end
+end
+
+

--- a/src/CUTEst.jl
+++ b/src/CUTEst.jl
@@ -2,8 +2,7 @@
 
 module CUTEst
 
-push!(LOAD_PATH, Pkg.dir("MathProgBase","src","NLP"))
-using NLP  # Defines NLPModelMeta.
+importall NLPModels
 using Compat
 import Base.Libdl.dlsym
 
@@ -12,8 +11,10 @@ global cutest_instances = 0
 
 export CUTEstModel, sifdecoder, cutest_finalize
 
-type CUTEstModel
+type CUTEstModel <: AbstractNLPModel
   meta    :: NLPModelMeta;
+
+  counters :: Counters
 end
 
 const outsdif = "OUTSDIF.d";
@@ -155,7 +156,7 @@ function CUTEstModel(name :: ASCIIString; decode :: Bool=true, verbose = false)
                       nlin=nlin, nnln=nnln,
                       name=splitext(name)[1]);
 
-  nlp = CUTEstModel(meta)
+  nlp = CUTEstModel(meta, Counters())
 
   cutest_instances += 1;
   return nlp

--- a/src/julia_interface.jl
+++ b/src/julia_interface.jl
@@ -2,6 +2,20 @@ export objcons, objgrad, obj, grad, grad!,
        cons_coord, cons, cons!, jac_coord, jac,
        hess_coord, hess, hprod, hprod!
 
+import NLPModels.obj
+import NLPModels.grad
+import NLPModels.grad!
+import NLPModels.hess
+import NLPModels.hprod
+import NLPModels.hprod!
+import NLPModels.cons
+import NLPModels.cons!
+import NLPModels.jac
+import NLPModels.jprod
+import NLPModels.jprod!
+import NLPModels.jtprod
+import NLPModels.jtprod!
+
 """    objcons(nlp, x)
 
 Computes the objective function and constraint vector values at x.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ for problem in ["HS32", "HS4"]
   include("finalize_test.jl")
 end
 
-problems = readdir(get(ENV, "MASTSIF", "") )
+problems = randsubseq(readdir(get(ENV, "MASTSIF", "") ), 0.05)
 
 for p in problems
   if !contains(p, "SIF")

--- a/travisCI/setup_travis_linux.sh
+++ b/travisCI/setup_travis_linux.sh
@@ -1,20 +1,8 @@
 #!/bin/bash
 set -ev
 
-# Install LinuxBrew.
-sudo apt-get update
-sudo apt-get install build-essential curl git m4 ruby texinfo libbz2-dev libcurl4-openssl-dev libexpat-dev libncurses-dev zlib1g-dev libgsl0-dev
-echo -ne '\n' | ruby -e "$(wget -O- https://raw.github.com/Homebrew/linuxbrew/go/install)"
+sudo apt-get update -qq
+sudo apt-get install -y gfortran libgsl0-dev
 
-# Symlink GCC to avoid installing Homebrew GCC.
-gccver=$(gcc -dumpversion |cut -d. -f1,2)
-ln -s $(which gcc) $HOME/.linuxbrew/bin/gcc-${gccver}
-ln -s $(which g++) $HOME/.linuxbrew/bin/g++-$(g++ -dumpversion |cut -d. -f1,2)
-
-# Ensure GFORTRAN is available.
-sudo apt-get -y install gfortran-${gccver}
-ln -s $(which gfortran-${gccver}) $HOME/.linuxbrew/bin/gfortran-${gccver}
-ln -s $(which gfortran-${gccver}) $HOME/.linuxbrew/bin/gfortran
-
-# Ensure BLAS and LAPACK are available.
-sudo apt-get -y install libblas-dev liblapack-dev
+gfover=$(gfortran -dumpversion | cut -f1,2 -d.)
+sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/$gfover/libgfortran.so /usr/local/lib


### PR DESCRIPTION
Two major changes.

- bindeps: Install CUTEst locally automatically for use inside CUTEst.jl
- use NLPModels.jl: Last "basic" main package for NLPModels.jl (Along with JuMP, Ampl and Simple)